### PR TITLE
fix: corrige RAG não encontrando chunks de módulos intermediários

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -227,8 +227,8 @@ def _render_answer(answer: str, sources: list[dict[str, Any]]) -> str:
 def consulta_institucional(
     question: str,
     *,
-    k: int = 6,
-    score_threshold: float = 0.60,
+    k: int = 12,
+    score_threshold: float = 0.35,
     conversation_context: str = "",
     user_profile: str = "",
 ) -> dict[str, Any]:

--- a/apps/core/documents/agents/processing_agent.py
+++ b/apps/core/documents/agents/processing_agent.py
@@ -30,7 +30,7 @@ def _calculate_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _split_semantic_chunks(text: str, chunk_size: int = 500, chunk_overlap: int = 150) -> list:
+def _split_semantic_chunks(text: str, chunk_size: int = 800, chunk_overlap: int = 150) -> list:
     """
     Divide o texto em chunks semanticos respeitando estrutura normativa.
     Aumentamos o overlap para 150 para garantir que o contexto de tabelas/listas não se perca entre chunks.
@@ -106,7 +106,10 @@ def processar_conteudo(extracao: dict) -> dict:
         chunks_texto = _split_semantic_chunks(texto)
 
         for i, chunk_text in enumerate(chunks_texto):
-            embedding = _generate_embedding(chunk_text)
+            # Prefixa o título no texto do chunk para que buscas pelo nome do
+            # documento encontrem todos os chunks, não apenas o primeiro.
+            chunk_text_for_embedding = f"{titulo}\n{chunk_text}" if titulo and titulo not in chunk_text else chunk_text
+            embedding = _generate_embedding(chunk_text_for_embedding)
 
             chunk_id = str(uuid.uuid4())
             content_hash = _calculate_hash(chunk_text)


### PR DESCRIPTION
- Aumenta k de 6 para 12 em consulta_institucional para buscar mais chunks no ChromaDB, evitando que módulos V+ sejam cortados por limite
- Reduz score_threshold de 0.60 para 0.35 para não filtrar chunks com relevância moderada (módulos sem o título do documento no texto)
- Aumenta chunk_size de 500 para 800 caracteres para que um módulo inteiro de horário caiba em um único chunk
- Prefixa o título do documento no embedding de cada chunk, garantindo que buscas por "ADS" retornem todos os módulos e não apenas o primeiro