### PR TITLE
fix: normaliza embeddings para corrigir distâncias L2 semanticamente …

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -237,7 +237,7 @@ def consulta_institucional(
     question: str,
     *,
     k: int = 12,
-    score_threshold: float = 0.35,
+    score_threshold: float = 0.50,
     conversation_context: str = "",
     user_profile: str = "",
 ) -> dict[str, Any]:

--- a/apps/core/documents/agents/processing_agent.py
+++ b/apps/core/documents/agents/processing_agent.py
@@ -13,8 +13,12 @@ _embedding_model = None
 def _get_embedding_model():
     global _embedding_model
     if _embedding_model is None:
+        # normalize_embeddings=True é obrigatório para o modelo paraphrase-multilingual-MiniLM-L12-v2.
+        # Sem normalização, os vetores têm norma L2 ~10-14, fazendo a distância L2 ser dominada
+        # pela magnitude (não pela direção semântica), tornando todos os scores igualmente baixos.
         _embedding_model = HuggingFaceEmbeddings(
-            model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+            model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+            encode_kwargs={"normalize_embeddings": True},
         )
     return _embedding_model
 

--- a/apps/core/documents/services/vectorstore_service.py
+++ b/apps/core/documents/services/vectorstore_service.py
@@ -10,8 +10,10 @@ def setup_vectorstore():
     project_root = os.path.abspath(os.path.join(base_dir, "..", "..", "..", ".."))
     persist_path = os.path.join(project_root, "chroma_db")
 
+    # normalize_embeddings=True deve corresponder ao que foi usado na indexação.
     embeddings = HuggingFaceEmbeddings(
-        model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+        model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+        encode_kwargs={"normalize_embeddings": True},
     )
 
     vectorstore = Chroma(


### PR DESCRIPTION
…inválidas

O modelo paraphrase-multilingual-MiniLM-L12-v2 é treinado para similaridade de cosseno, mas os embeddings eram armazenados/consultados sem normalização. Vetores com norma L2 ~10-14 fazem a distância L2 ser dominada pela magnitude e não pela direção semântica, resultando em scores ~0.06 para TODOS os chunks independente de relevância — equivalente a busca aleatória.

Com normalize_embeddings=True, vetores ficam na esfera unitária (norma=1), L2 ∈ [0,2] mapeia diretamente para similaridade de cosseno, e scores passam a refletir semântica real (docs relacionados atingem 0.6-0.9).

Ajuste: score_threshold 0.35→0.50 (cos_sim>0.5 para threshold=0.50 com L2).

AÇÃO NECESSÁRIA: deletar chroma_db/ e re-indexar todos os documentos.