### PR TITLE
fix: aumenta limite de upload para 150 MB (Nginx + Flask)

### DIFF
--- a/apps/config.py
+++ b/apps/config.py
@@ -20,7 +20,8 @@ class Config(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     CHAT_HISTORY_LIMIT = int(os.getenv("CHAT_HISTORY_LIMIT", "12"))
     UPLOAD_FOLDER = os.path.join(basedir, "uploads")
-    ALLOWED_EXTENSIONS = {"pdf"}
+    ALLOWED_EXTENSIONS = {"pdf", "txt", "docx"}
+    MAX_CONTENT_LENGTH = int(os.getenv("MAX_UPLOAD_MB", "150")) * 1024 * 1024
 
     DB_ENGINE   = os.getenv('DB_ENGINE'   , None)
     DB_USERNAME = os.getenv('DB_USERNAME' , None)

--- a/nginx/appseed-app.conf
+++ b/nginx/appseed-app.conf
@@ -8,6 +8,9 @@ server {
     listen 80;
     server_name localhost;
 
+    # Permite upload de PDFs grandes (até 150 MB)
+    client_max_body_size 150M;
+
 #    location /.well-known/acme-challenge/ {
 #        root /var/www/certbot;
 #    }
@@ -19,7 +22,7 @@ server {
         proxy_send_timeout    300s;
         proxy_read_timeout    300s;
     }
-    
+
 }
 
 # server {


### PR DESCRIPTION
Nginx sem client_max_body_size usa padrão de 1 MB, causando 413 em PDFs maiores. Flask sem MAX_CONTENT_LENGTH não valida no lado da aplicação.

- nginx: client_max_body_size 150M
- Flask: MAX_CONTENT_LENGTH = 150 MB (configurável via MAX_UPLOAD_MB env var)
- ALLOWED_EXTENSIONS ampliado para incluir txt e docx (já suportados pela extração)