### PR TITLE
feat: adiciona rota conversacional e injeção de data no supervisor

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -321,14 +321,14 @@ def consulta_institucional(
     score_threshold: float = 0.40,
     conversation_context: str = "",
     user_profile: str = "",
+    today: str = "",
 ) -> dict[str, Any]:
-    # NOVO: Contextualiza a busca antes de ir ao banco vetorial
+    from datetime import datetime
+    today = today or datetime.now().strftime("%d/%m/%Y")
+
     search_query = _generate_search_query(question, conversation_context, user_profile)
-    
-    # Agora o retrieval usa a query expandida (ex: "horários aula ADS V módulo") 
-    # em vez de "horários para minha turma"
     retrieval = retrieve_with_threshold(search_query, k=k, score_threshold=score_threshold)
-    
+
     if retrieval.get("status") != "success":
         rendered = f"Resposta:\n{NOT_FOUND_ANSWER}"
         return {
@@ -352,6 +352,7 @@ def consulta_institucional(
             "not_found_answer": NOT_FOUND_ANSWER,
             "conversation_context": (conversation_context or "").strip() or "Sem histórico relevante.",
             "user_profile": (user_profile or "").strip() or "Nenhuma informação adicional conhecida.",
+            "today": today,
         }
     )
 

--- a/apps/core/chat/agents/supervisor.py
+++ b/apps/core/chat/agents/supervisor.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from typing import Any
 
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
 
-from .institutional_agent import consulta_institucional
+from apps.core.chat.prompts import get_conversational_prompt
+from .institutional_agent import consulta_institucional, _get_llm
 from .web_agent import responder_web
 
 
@@ -40,16 +44,63 @@ def _friendly_fallback(question: str, user_profile: str = "") -> str:
     )
 
 
+def _responder_conversacional(
+    question: str,
+    conversation_context: str,
+    user_profile: str,
+    today: str,
+) -> dict[str, Any]:
+    """
+    Terceira rota do supervisor: aciona o LLM com base no histórico da conversa
+    e na data de hoje. Usada para perguntas como 'Então já passou?' ou 'Que dia
+    é hoje?' que dependem do contexto conversacional, não de documentos.
+    """
+    if not conversation_context:
+        return {"status": "not_found", "answer": "", "rendered": ""}
+
+    llm = _get_llm()
+    try:
+        chain = (
+            ChatPromptTemplate.from_template(get_conversational_prompt())
+            | llm
+            | StrOutputParser()
+        )
+        answer = chain.invoke(
+            {
+                "question": (question or "").strip(),
+                "conversation_context": conversation_context,
+                "user_profile": (user_profile or "").strip() or "Nenhuma informação adicional conhecida.",
+                "today": today,
+            }
+        )
+        answer = (answer or "").strip()
+        if not answer:
+            return {"status": "not_found", "answer": "", "rendered": ""}
+
+        print(f"[SUPERVISOR][CONV] Resposta conversacional gerada para: '{question[:80]}'")
+        return {
+            "status": "success",
+            "answer": answer,
+            "sources": [],
+            "rendered": f"Resposta:\n{answer}",
+        }
+    except Exception as e:
+        print(f"[SUPERVISOR][CONV] Erro na rota conversacional: {e}")
+        return {"status": "not_found", "answer": "", "rendered": ""}
+
+
 def supervisor(state: dict[str, Any], config: dict[str, Any] | None = None) -> dict[str, Any]:
     messages = state.get("messages") or []
     question = _last_user_message(messages)
     conversation_context = _conversation_context(messages, limit=12)
     user_profile = str(state.get("user_profile") or "").strip()
+    today = datetime.now().strftime("%d/%m/%Y")
 
     rag = consulta_institucional(
         question,
         conversation_context=conversation_context,
         user_profile=user_profile,
+        today=today,
     )
     decision = {"route": "consulta_institucional", "rag_status": rag.get("status")}
 
@@ -65,7 +116,18 @@ def supervisor(state: dict[str, Any], config: dict[str, Any] | None = None) -> d
             "rag_status": rag.get("status"),
             "web_status": web.get("status"),
         }
-        result = web if web.get("status") == "success" else web
+        result = web
+
+        if web.get("status") != "success" and conversation_context:
+            conv = _responder_conversacional(question, conversation_context, user_profile, today)
+            if conv.get("status") == "success":
+                decision = {
+                    "route": "conversacional",
+                    "rag_status": rag.get("status"),
+                    "web_status": web.get("status"),
+                    "conv_status": conv.get("status"),
+                }
+                result = conv
 
     if result.get("status") == "success":
         rendered = (result.get("rendered") or "").strip() or _friendly_fallback(question, user_profile)
@@ -83,6 +145,7 @@ def supervisor(state: dict[str, Any], config: dict[str, Any] | None = None) -> d
             "rag_docs": (rag.get("docs") or [])[:6],
             "conversation_context": conversation_context,
             "user_profile": user_profile,
+            "today": today,
         },
         ensure_ascii=False,
     )

--- a/apps/core/chat/prompts/__init__.py
+++ b/apps/core/chat/prompts/__init__.py
@@ -1,3 +1,4 @@
+from .conversational_prompt import get_conversational_prompt
 from .feedback_prompt import get_feedback_rewrite_prompt
 from .qa_prompt import get_qa_prompt
 from .rag_prompt import get_rag_answer_prompt
@@ -10,4 +11,5 @@ __all__ = [
     "get_rag_answer_prompt",
     "get_web_answer_prompt",
     "get_feedback_rewrite_prompt",
+    "get_conversational_prompt",
 ]

--- a/apps/core/chat/prompts/conversational_prompt.py
+++ b/apps/core/chat/prompts/conversational_prompt.py
@@ -1,0 +1,21 @@
+def get_conversational_prompt():
+    return """
+Você é um assistente institucional do IFPI. Hoje é {today}.
+
+Informações conhecidas sobre o usuário:
+{user_profile}
+
+Histórico recente da conversa (use como base para responder):
+{conversation_context}
+
+Pergunta atual:
+{question}
+
+INSTRUÇÕES:
+1. Responda com base NO HISTÓRICO DA CONVERSA acima e no seu conhecimento geral — NÃO invente dados que não estejam no histórico.
+2. Você CONHECE a data de hoje: {today}. Use isso para raciocinar sobre datas passadas, futuras ou prazos mencionados na conversa.
+3. Mantenha o escopo do IFPI: responda apenas sobre assuntos relacionados à instituição (aulas, provas, horários, procedimentos, professores, cursos). Recuse educadamente perguntas completamente fora desse escopo.
+4. Se a pergunta não puder ser respondida nem pelo histórico nem pela data de hoje, diga claramente que não tem essa informação.
+5. Tom natural, direto e humano. Use Markdown quando ajudar na leitura.
+6. NÃO cite fontes nesta resposta — ela é baseada no contexto conversacional, não em documentos.
+"""

--- a/apps/core/chat/prompts/rag_prompt.py
+++ b/apps/core/chat/prompts/rag_prompt.py
@@ -1,6 +1,6 @@
 def get_rag_answer_prompt():
     rag_prompt = """
-Você é um assistente institucional do IFPI.
+Você é um assistente institucional do IFPI. Hoje é {today}.
 
 Informações importantes já conhecidas sobre o usuário:
 {user_profile}
@@ -19,7 +19,7 @@ Instruções CRÍTICAS:
 2. Se o Contexto não contiver a informação necessária de forma explícita, responda exatamente: {not_found_answer}
 3. É proibido inventar fatos, prazos, nomes, artigos, números, procedimentos ou interpretações que não estejam explícitos no Contexto.
 4. Produza SOMENTE o texto da resposta (sem seção de fontes, sem listas de links e sem citar "Fonte 1", etc.).
-5. Use o histórico recente apenas para manter continuidade, resolver referências como "isso", "aquilo", "antes", "o documento anterior", sem inventar fatos novos.
+5. Use o histórico recente apenas para manter continuidade e resolver referências ("isso", "aquilo", "antes"). Você pode usar a data de hoje para raciocinar sobre se algo já ocorreu ou está por vir.
 6. Se houver informação conhecida sobre o usuário, use isso apenas para personalizar tom e contexto; nunca invente dados pessoais.
 7. Use Markdown com parágrafos curtos, tom natural e linguagem humana.
 """


### PR DESCRIPTION
- Supervisor agora injeta a data de hoje em todas as chamadas ao RAG e ao LLM
- Nova função _responder_conversacional() usa o histórico da conversa + data atual para responder perguntas como 'Então já passou?' ou 'Que dia é hoje?' sem precisar de documentos ou busca web
- Terceira rota do supervisor: RAG → Web → Conversacional (com guardrails IFPI)
- Novo prompt conversacional com escopo restrito ao IFPI, tom natural e ciente da data
- consulta_institucional() recebe e propaga o parâmetro today para o prompt RAG