### PR TITLE
fix: rota conversacional ativa mesmo sem histórico de conversa

### DIFF
--- a/apps/core/chat/agents/supervisor.py
+++ b/apps/core/chat/agents/supervisor.py
@@ -53,10 +53,9 @@ def _responder_conversacional(
     """
     Terceira rota do supervisor: aciona o LLM com base no histórico da conversa
     e na data de hoje. Usada para perguntas como 'Então já passou?' ou 'Que dia
-    é hoje?' que dependem do contexto conversacional, não de documentos.
+    é hoje?' que dependem do contexto conversacional ou da data atual.
+    Não exige histórico — a data sozinha já permite responder algumas perguntas.
     """
-    if not conversation_context:
-        return {"status": "not_found", "answer": "", "rendered": ""}
 
     llm = _get_llm()
     try:
@@ -118,7 +117,7 @@ def supervisor(state: dict[str, Any], config: dict[str, Any] | None = None) -> d
         }
         result = web
 
-        if web.get("status") != "success" and conversation_context:
+        if web.get("status") != "success":
             conv = _responder_conversacional(question, conversation_context, user_profile, today)
             if conv.get("status") == "success":
                 decision = {

--- a/apps/core/chat/prompts/conversational_prompt.py
+++ b/apps/core/chat/prompts/conversational_prompt.py
@@ -5,17 +5,17 @@ Você é um assistente institucional do IFPI. Hoje é {today}.
 Informações conhecidas sobre o usuário:
 {user_profile}
 
-Histórico recente da conversa (use como base para responder):
+Histórico recente da conversa:
 {conversation_context}
 
 Pergunta atual:
 {question}
 
 INSTRUÇÕES:
-1. Responda com base NO HISTÓRICO DA CONVERSA acima e no seu conhecimento geral — NÃO invente dados que não estejam no histórico.
-2. Você CONHECE a data de hoje: {today}. Use isso para raciocinar sobre datas passadas, futuras ou prazos mencionados na conversa.
+1. Você CONHECE a data de hoje: {today}. Use isso sempre que a pergunta envolver datas, prazos ou "já passou / ainda vai acontecer".
+2. Se houver histórico de conversa, use-o para contextualizar a resposta. Se não houver histórico, responda apenas com base na data de hoje e no seu conhecimento geral sobre o IFPI.
 3. Mantenha o escopo do IFPI: responda apenas sobre assuntos relacionados à instituição (aulas, provas, horários, procedimentos, professores, cursos). Recuse educadamente perguntas completamente fora desse escopo.
-4. Se a pergunta não puder ser respondida nem pelo histórico nem pela data de hoje, diga claramente que não tem essa informação.
+4. Se a pergunta não puder ser respondida com a data de hoje nem com o histórico, diga claramente que não tem essa informação.
 5. Tom natural, direto e humano. Use Markdown quando ajudar na leitura.
-6. NÃO cite fontes nesta resposta — ela é baseada no contexto conversacional, não em documentos.
+6. NÃO cite fontes nesta resposta.
 """


### PR DESCRIPTION
A rota conversacional agora é sempre tentada quando RAG e web falham, independente de haver histórico. Isso permite responder perguntas como 'Que dia é hoje?' mesmo sendo a primeira mensagem da conversa, usando apenas a data injetada em {today}.

- Remove guard 'if not conversation_context' em _responder_conversacional
- Remove condição 'and conversation_context' no supervisor
- Atualiza prompt: instrução 1 prioriza a data; sem histórico responde com base em {today} e conhecimento geral do IFPI