### PR TITLE
fix: injeção direta de docs de avaliação + anti-alucinação conversaci…

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -139,6 +139,69 @@ def _expand_with_sibling_chunks(
     return combined
 
 
+_PROVA_KEYWORDS = frozenset({
+    "prova", "avaliação", "avaliações", "bimestral", "bimestrais",
+    "quantos dias", "quando foi", "data da prova", "teste", "exame",
+})
+
+
+def _inject_eval_docs(
+    question: str,
+    vectorstore: Any,
+    seen_map: dict[str, tuple[Any, float]],
+    base_relevance: float = 0.42,
+) -> list[tuple[Any, float]]:
+    """
+    Quando a pergunta menciona provas/avaliações, busca DIRETAMENTE todos os chunks
+    de documentos de avaliação via metadados, contornando o gap semântico entre
+    queries sobre datas de prova e o formato dos documentos indexados (grade/calendário).
+    """
+    q_lower = (question or "").lower()
+    if not any(kw in q_lower for kw in _PROVA_KEYWORDS):
+        return []
+
+    collection = getattr(vectorstore, "_collection", None)
+    if collection is None:
+        return []
+
+    try:
+        all_data = collection.get(include=["metadatas"])
+        all_metas = all_data.get("metadatas") or []
+
+        eval_crencas: set[str] = set()
+        for meta in all_metas:
+            titulo = str(meta.get("titulo") or meta.get("documento_titulo") or "").lower()
+            if any(kw in titulo for kw in ("avali", "prova", "bimestral")):
+                crenca = str(meta.get("id_crenca", ""))
+                if crenca:
+                    eval_crencas.add(crenca)
+
+        if not eval_crencas:
+            print("[RAG][EVAL_INJECT] Nenhum documento de avaliação nos metadados.")
+            return []
+
+        print(f"[RAG][EVAL_INJECT] Injetando chunks de {len(eval_crencas)} documento(s) de avaliação.")
+        from langchain_core.documents import Document
+
+        extra: list[tuple[Any, float]] = []
+        for crenca in eval_crencas:
+            result = collection.get(
+                where={"id_crenca": {"$eq": crenca}},
+                include=["documents", "metadatas"],
+            )
+            for doc_text, meta in zip(result.get("documents") or [], result.get("metadatas") or []):
+                chunk_id = str(meta.get("chunk_id", "") or hash(doc_text))
+                if chunk_id in seen_map:
+                    continue
+                extra.append((Document(page_content=doc_text, metadata=meta), base_relevance))
+
+        return extra
+
+    except Exception as e:
+        print(f"[RAG][EVAL_INJECT] Erro: {e}")
+        return []
+
+
 def retrieve_with_threshold(
     question: str,
     *,
@@ -183,6 +246,17 @@ def retrieve_with_threshold(
         prev = seen_map.get(str(doc_id))
         if not prev or relevance > prev[1]:
             seen_map[str(doc_id)] = (doc, relevance)
+
+    # Injeção direta de documentos de avaliação quando a pergunta menciona provas
+    eval_extra = _inject_eval_docs(q, vectorstore, seen_map)
+    for doc, rel in eval_extra:
+        doc_id = str(
+            getattr(doc, "id", None)
+            or getattr(doc, "metadata", {}).get("chunk_id")
+            or hash(getattr(doc, "page_content", ""))
+        )
+        if doc_id not in seen_map:
+            seen_map[doc_id] = (doc, rel)
 
     docs_with_scores = list(seen_map.values())
 

--- a/apps/core/chat/prompts/conversational_prompt.py
+++ b/apps/core/chat/prompts/conversational_prompt.py
@@ -11,11 +11,10 @@ Histórico recente da conversa:
 Pergunta atual:
 {question}
 
-INSTRUÇÕES:
-1. Você CONHECE a data de hoje: {today}. Use isso sempre que a pergunta envolver datas, prazos ou "já passou / ainda vai acontecer".
-2. Se houver histórico de conversa, use-o para contextualizar a resposta. Se não houver histórico, responda apenas com base na data de hoje e no seu conhecimento geral sobre o IFPI.
+INSTRUÇÕES CRÍTICAS:
+1. Você CONHECE a data de hoje: {today}. Use isso para raciocinar sobre "já passou", "falta quanto tempo", "há quantos dias" quando o histórico contiver a data de referência.
+2. Responda SOMENTE com informações que estejam EXPLICITAMENTE no histórico da conversa acima. NÃO invente datas, nomes, números ou fatos que não estejam no histórico. Se a informação não estiver no histórico, diga claramente: "Não tenho essa informação no nosso histórico de conversa."
 3. Mantenha o escopo do IFPI: responda apenas sobre assuntos relacionados à instituição (aulas, provas, horários, procedimentos, professores, cursos). Recuse educadamente perguntas completamente fora desse escopo.
-4. Se a pergunta não puder ser respondida com a data de hoje nem com o histórico, diga claramente que não tem essa informação.
-5. Tom natural, direto e humano. Use Markdown quando ajudar na leitura.
-6. NÃO cite fontes nesta resposta.
+4. Tom natural, direto e humano. Use Markdown quando ajudar na leitura.
+5. NÃO cite fontes nesta resposta.
 """


### PR DESCRIPTION
…onal

Problema 1 — RAG não recupera Avaliações Bimestrais: O documento de avaliações tem formato de grade (datas + nomes), cujo embedding não é semanticamente próximo de queries como "prova de algoritmos" ou "quantos dias". Fix: _inject_eval_docs() — quando a pergunta menciona "prova", "avaliação", "bimestral", etc., busca diretamente no ChromaDB todos os chunks de documentos cujo título contém esses termos (via metadados, sem depender de similaridade). Garante que Avaliações Bimestrais sempre entre no contexto do LLM nesses casos.

Problema 2 — Rota conversacional alucinando datas: O prompt dizia "no seu conhecimento geral", permitindo ao LLM inventar datas (ex: "15 de abril", "16 de abril") que não existiam no histórico. Fix: instrução CRÍTICA explícita de responder SOMENTE com o que está no histórico. Se não estiver no histórico → diz que não tem a informação.