### PR TITLE
feat: novo fluxo de feedback negativo com modal e dashboard atualizado

### DIFF
--- a/apps/authentication/routes/admin_routes.py
+++ b/apps/authentication/routes/admin_routes.py
@@ -5,6 +5,7 @@ Rotas administrativas relacionadas a documentos, versoes, logs e feedbacks.
 
 import re
 import os
+import json
 import uuid
 from werkzeug.utils import secure_filename
 from flask import flash, redirect, render_template, request, url_for, current_app
@@ -28,32 +29,59 @@ def _normalize_feedback_text(value: str) -> str:
     return re.sub(r"\s+", " ", (value or "").strip().lower())
 
 
+def _parse_feedback_comment(feedback: ChatFeedback) -> dict:
+    """Extrai user_comment e conversation_history do campo comment (JSON)."""
+    raw = (feedback.comment or "").strip()
+    if not raw:
+        return {"user_comment": "", "conversation_history": ""}
+    try:
+        data = json.loads(raw)
+        return {
+            "user_comment": str(data.get("user_comment") or ""),
+            "conversation_history": str(data.get("conversation_history") or ""),
+        }
+    except Exception:
+        # Formato legado (texto puro da resposta revisada)
+        return {"user_comment": "", "conversation_history": raw}
+
+
 def _classify_feedback_failure(feedback: ChatFeedback) -> str:
     answer = _normalize_feedback_text(feedback.answer)
     thoughts = _normalize_feedback_text(getattr(getattr(feedback, "bot_message", None), "thoughts", ""))
+    parsed = _parse_feedback_comment(feedback)
+    user_comment = _normalize_feedback_text(parsed["user_comment"])
 
     if not answer:
         return "Resposta vazia"
-    if "não encontrei" in answer or "não localizei" in answer or "rag_status" in thoughts and "not_found" in thoughts:
+    if user_comment:
+        # Classifica pela palavra-chave no comentário do usuário
+        if any(w in user_comment for w in ("errado", "incorreto", "errada", "incorreta", "errou")):
+            return "Informação incorreta"
+        if any(w in user_comment for w in ("não encontrou", "não achou", "não encontrei", "não localizou")):
+            return "RAG sem contexto suficiente"
+        if any(w in user_comment for w in ("incompleto", "faltou", "faltando", "incompleta")):
+            return "Resposta incompleta"
+    if "não encontrei" in answer or "não localizei" in answer:
         return "RAG sem contexto suficiente"
     if "tavily_web" in thoughts or '"route": "tavily_web"' in thoughts:
         return "Fallback para web"
     if len(answer) < 140:
         return "Resposta curta ou genérica"
-    return "Necessita reformulação"
+    return "Necessita investigação"
 
 
 def _feedback_dashboard_data(feedbacks: list[ChatFeedback]) -> dict:
     failure_counts: dict[str, int] = {}
     repeated_questions: dict[str, dict[str, int | str]] = {}
-    revised_count = 0
+    with_comment_count = 0
 
     for feedback in feedbacks:
         label = _classify_feedback_failure(feedback)
         failure_counts[label] = failure_counts.get(label, 0) + 1
 
-        if (feedback.comment or "").strip():
-            revised_count += 1
+        parsed = _parse_feedback_comment(feedback)
+        if parsed["user_comment"].strip():
+            with_comment_count += 1
 
         normalized_question = _normalize_feedback_text(feedback.question)
         if normalized_question:
@@ -78,7 +106,7 @@ def _feedback_dashboard_data(feedbacks: list[ChatFeedback]) -> dict:
 
     stats = {
         "total_down": len(feedbacks),
-        "revised_count": revised_count,
+        "with_comment_count": with_comment_count,
         "top_failure": recurrent_failures[0]["label"] if recurrent_failures else "Sem dados",
     }
     return {
@@ -200,6 +228,7 @@ def admin_feedbacks():
         recurrent_failures=dashboard["recurrent_failures"],
         recurring_questions=dashboard["recurring_questions"],
         classify_feedback_failure=_classify_feedback_failure,
+        parse_feedback_comment=_parse_feedback_comment,
     )
 
 

--- a/apps/core/chat/services/feedback_service.py
+++ b/apps/core/chat/services/feedback_service.py
@@ -1,3 +1,5 @@
+import json
+
 from flask_login import current_user
 
 from apps import db
@@ -7,7 +9,7 @@ from .memory_service import build_effective_user_profile
 from .serialization_service import format_conversation_context
 
 
-def submit_feedback(*, bot_message_id: int, rating: str, improve_response) -> tuple[dict, int]:
+def submit_feedback(*, bot_message_id: int, rating: str, user_comment: str = "") -> tuple[dict, int]:
     rating = str(rating or "").strip().lower()
     if rating not in {"up", "down"}:
         return {"error": "Avaliação inválida."}, 400
@@ -30,11 +32,30 @@ def submit_feedback(*, bot_message_id: int, rating: str, improve_response) -> tu
         .first()
     )
 
+    # Captura o histórico completo da thread para diagnóstico
+    conversation_history = ""
+    if rating == "down":
+        history_messages = get_recent_thread_messages(bot_message.thread_id, limit=chat_history_limit())
+        conversation_history = format_conversation_context(history_messages, limit=chat_history_limit())
+
+    # Monta o payload de diagnóstico salvo em comment (JSON)
+    comment_payload = None
+    if rating == "down":
+        comment_payload = json.dumps(
+            {
+                "user_comment": user_comment,
+                "conversation_history": conversation_history,
+            },
+            ensure_ascii=False,
+        )
+
     feedback = ChatFeedback.query.filter_by(bot_message_id=bot_message.id).first()
     if feedback:
         feedback.rating = rating
         feedback.question = user_message.content if user_message else ""
         feedback.answer = bot_message.content or ""
+        if comment_payload is not None:
+            feedback.comment = comment_payload
     else:
         feedback = ChatFeedback(
             user_id=current_user.id if current_user.is_authenticated else None,
@@ -44,48 +65,9 @@ def submit_feedback(*, bot_message_id: int, rating: str, improve_response) -> tu
             question=user_message.content if user_message else "",
             answer=bot_message.content or "",
             rating=rating,
+            comment=comment_payload,
         )
         db.session.add(feedback)
 
-    response_payload = {"ok": True, "bot_message_id": bot_message.id, "rating": rating}
-
-    if rating == "down":
-        history_messages = get_recent_thread_messages(bot_message.thread_id, limit=chat_history_limit())
-        user_id = current_user.id if current_user.is_authenticated else None
-        _, user_profile, _ = build_effective_user_profile(
-            user_id=user_id,
-            thread_id=bot_message.thread_id,
-            history_messages=history_messages,
-        )
-
-        improved = improve_response(
-            question=user_message.content if user_message else "",
-            previous_answer=bot_message.content or "",
-            conversation_context=format_conversation_context(history_messages, limit=chat_history_limit()),
-            user_profile=user_profile,
-        )
-        revised_text = (improved.get("answer") or "").strip()
-        if revised_text:
-            revised_content = f"**Resposta revisada**\n\n{revised_text}"
-            revised_message = ChatMessage(
-                user_id=user_id,
-                thread_id=bot_message.thread_id,
-                sender="bot",
-                content=revised_content,
-            )
-            db.session.add(revised_message)
-            feedback.comment = revised_content
-            db.session.commit()
-            response_payload.update(
-                {
-                    "revised_response": revised_content,
-                    "revised_bot_message_id": revised_message.id,
-                    "revised_feedback_rating": None,
-                    "revised_has_rag_context": bool(improved.get("has_rag_context")),
-                    "revised_sources": improved.get("sources") or [],
-                }
-            )
-            return response_payload, 200
-
     db.session.commit()
-    return response_payload, 200
+    return {"ok": True, "bot_message_id": bot_message.id, "rating": rating}, 200

--- a/apps/core/routes_parts/feedback_routes.py
+++ b/apps/core/routes_parts/feedback_routes.py
@@ -4,17 +4,12 @@ from apps.core import blueprint
 from apps.core.chat.services.feedback_service import submit_feedback
 
 
-def _get_improve_callable():
-    import apps.core as public_core
-
-    return public_core.melhorar_resposta_com_feedback
-
-
 @blueprint.route("/chatbot/feedback", methods=["POST"])
 def chatbot_feedback():
     payload = request.get_json(silent=True) or {}
     rating = str(payload.get("rating") or "").strip().lower()
     bot_message_id = payload.get("bot_message_id")
+    user_comment = str(payload.get("user_comment") or "").strip()
 
     try:
         bot_message_id = int(bot_message_id)
@@ -24,6 +19,6 @@ def chatbot_feedback():
     response_payload, status = submit_feedback(
         bot_message_id=bot_message_id,
         rating=rating,
-        improve_response=_get_improve_callable(),
+        user_comment=user_comment,
     )
     return jsonify(response_payload), status

--- a/apps/static/assets/css/index-chat.css
+++ b/apps/static/assets/css/index-chat.css
@@ -764,3 +764,144 @@ body.app.chat-layout-page {
   0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
   40% { transform: translateY(-3px); opacity: 0.8; }
  }
+
+/* ── Feedback modal ─────────────────────────────────────── */
+.feedback-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 16px;
+  animation: fadeIn 0.15s ease;
+}
+
+.feedback-modal {
+  background: var(--surface);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  animation: slideUp 0.18s ease;
+}
+
+.feedback-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.feedback-modal-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.feedback-modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 4px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s, background 0.15s;
+}
+
+.feedback-modal-close:hover {
+  color: var(--text);
+  background: var(--border);
+}
+
+.feedback-modal-body {
+  padding: 16px 20px;
+}
+
+.feedback-modal-desc {
+  font-size: 0.82rem;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+.feedback-modal-textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 0.875rem;
+  color: var(--text);
+  background: var(--bg);
+  resize: vertical;
+  font-family: inherit;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.feedback-modal-textarea:focus {
+  outline: none;
+  border-color: var(--user);
+}
+
+.feedback-modal-charcount {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-align: right;
+  margin-top: 4px;
+}
+
+.feedback-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 12px 20px 18px;
+}
+
+.feedback-modal-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.feedback-modal-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.feedback-modal-btn-cancel {
+  background: var(--border);
+  color: var(--text);
+}
+
+.feedback-modal-btn-cancel:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.feedback-modal-btn-submit {
+  background: var(--user);
+  color: #fff;
+}
+
+.feedback-modal-btn-submit:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/apps/static/assets/js/index-chat.js
+++ b/apps/static/assets/js/index-chat.js
@@ -319,34 +319,92 @@ function setSidebarDropdownOpen(isOpen) {
   sidebarChatToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 }
 
+// --- Feedback modal state ---
+let _feedbackModalTarget = null; // { botMessageId, messageElement }
+
+function openFeedbackModal(botMessageId, messageElement) {
+  _feedbackModalTarget = { botMessageId, messageElement };
+  const overlay = document.getElementById('feedback-modal-overlay');
+  const textarea = document.getElementById('feedback-modal-text');
+  const charCount = document.getElementById('feedback-modal-chars');
+  if (!overlay) return;
+  textarea.value = '';
+  if (charCount) charCount.textContent = '0';
+  overlay.style.display = 'flex';
+  textarea.focus();
+}
+
+function closeFeedbackModal() {
+  const overlay = document.getElementById('feedback-modal-overlay');
+  if (overlay) overlay.style.display = 'none';
+  _feedbackModalTarget = null;
+}
+
+async function submitFeedbackModal() {
+  if (!_feedbackModalTarget) return;
+  const { botMessageId, messageElement } = _feedbackModalTarget;
+  const textarea = document.getElementById('feedback-modal-text');
+  const userComment = (textarea ? textarea.value : '').trim();
+  const submitBtn = document.getElementById('feedback-modal-submit');
+  if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Enviando...'; }
+
+  try {
+    const res = await fetch('/chatbot/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bot_message_id: botMessageId, rating: 'down', user_comment: userComment })
+    });
+    if (!res.ok) throw new Error('Erro ao enviar feedback');
+    const data = await res.json();
+    updateFeedbackState(messageElement, data.rating);
+    setFeedbackProcessingState(messageElement, 'Obrigado pelo feedback!');
+    setTimeout(() => setFeedbackProcessingState(messageElement, ''), 3000);
+    closeFeedbackModal();
+  } catch {
+    setFeedbackProcessingState(messageElement, 'Nao foi possivel enviar o feedback agora.');
+    setTimeout(() => setFeedbackProcessingState(messageElement, ''), 3000);
+    closeFeedbackModal();
+  } finally {
+    if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Enviar feedback'; }
+  }
+}
+
 async function sendFeedback(botMessageId, rating, messageElement) {
-  setFeedbackProcessingState(messageElement, rating === 'down' ? 'Estamos melhorando essa resposta para voce...' : '');
+  // Feedback positivo: envia diretamente sem modal
   try {
     const res = await fetch('/chatbot/feedback', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ bot_message_id: botMessageId, rating })
     });
-    if (!res.ok) {
-      setFeedbackProcessingState(messageElement, rating === 'down' ? 'Nao foi possivel revisar a resposta agora.' : '');
-      return;
-    }
+    if (!res.ok) return;
     const data = await res.json();
     updateFeedbackState(messageElement, data.rating);
-    if (rating === 'down' && data.revised_response) {
-      setFeedbackProcessingState(messageElement, 'Resposta revisada gerada. Veja abaixo.');
-      createMessageBubble('bot', data.revised_response, {
-        messageId: data.revised_bot_message_id,
-        feedbackRating: data.revised_feedback_rating || null,
-      });
-      await refreshConversationList();
-      return;
-    }
-    setFeedbackProcessingState(messageElement, '');
-  } catch (error) {
-    setFeedbackProcessingState(messageElement, rating === 'down' ? 'Nao foi possivel revisar a resposta agora.' : '');
+  } catch {
+    // silencioso para feedback positivo
   }
 }
+
+// Inicializa eventos do modal de feedback
+document.addEventListener('DOMContentLoaded', () => {
+  const closeBtn = document.getElementById('feedback-modal-close');
+  const cancelBtn = document.getElementById('feedback-modal-cancel');
+  const submitBtn = document.getElementById('feedback-modal-submit');
+  const overlay = document.getElementById('feedback-modal-overlay');
+  const textarea = document.getElementById('feedback-modal-text');
+  const charCount = document.getElementById('feedback-modal-chars');
+
+  if (closeBtn) closeBtn.addEventListener('click', closeFeedbackModal);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeFeedbackModal);
+  if (submitBtn) submitBtn.addEventListener('click', submitFeedbackModal);
+  if (overlay) overlay.addEventListener('click', (e) => { if (e.target === overlay) closeFeedbackModal(); });
+  if (textarea && charCount) {
+    textarea.addEventListener('input', () => { charCount.textContent = textarea.value.length; });
+  }
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay && overlay.style.display !== 'none') closeFeedbackModal();
+  });
+});
 
 function updateFeedbackState(messageElement, rating) {
   if (!messageElement) return;
@@ -419,12 +477,15 @@ function appendFeedbackControls(messageElement, botMessageId, feedbackRating = n
   downBtn.title = 'Não útil';
   downBtn.innerHTML = thumbsDownIcon;
 
-  [upBtn, downBtn].forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      await sendFeedback(botMessageId, btn.dataset.rating, messageElement);
-    });
-    wrapper.appendChild(btn);
+  upBtn.addEventListener('click', async () => {
+    await sendFeedback(botMessageId, 'up', messageElement);
   });
+  downBtn.addEventListener('click', () => {
+    // Abre modal para coletar comentário antes de enviar o feedback negativo
+    openFeedbackModal(botMessageId, messageElement);
+  });
+  wrapper.appendChild(upBtn);
+  wrapper.appendChild(downBtn);
 
   wrapper.prepend(label);
   contentDiv.appendChild(wrapper);

--- a/apps/templates/admin/feedbacks.html
+++ b/apps/templates/admin/feedbacks.html
@@ -8,25 +8,26 @@
     <a href="{{ url_for('authentication_blueprint.admin_docs') }}" class="btn btn-sm btn-link">Voltar</a>
   </div>
 
+  <!-- Cards de resumo -->
   <div class="row g-3 mb-4">
     <div class="col-md-4">
-      <div class="card h-100">
+      <div class="card h-100 border-0 shadow-sm">
         <div class="card-body">
           <div class="text-muted small mb-1">Total de respostas com 👎</div>
-          <div class="display-6 fw-bold">{{ stats.total_down }}</div>
+          <div class="display-6 fw-bold text-danger">{{ stats.total_down }}</div>
         </div>
       </div>
     </div>
     <div class="col-md-4">
-      <div class="card h-100">
+      <div class="card h-100 border-0 shadow-sm">
         <div class="card-body">
-          <div class="text-muted small mb-1">Revisadas automaticamente</div>
-          <div class="display-6 fw-bold">{{ stats.revised_count }}</div>
+          <div class="text-muted small mb-1">Com comentário do usuário</div>
+          <div class="display-6 fw-bold text-primary">{{ stats.with_comment_count }}</div>
         </div>
       </div>
     </div>
     <div class="col-md-4">
-      <div class="card h-100">
+      <div class="card h-100 border-0 shadow-sm">
         <div class="card-body">
           <div class="text-muted small mb-1">Falha mais recorrente</div>
           <div class="fw-semibold mt-2">{{ stats.top_failure }}</div>
@@ -35,9 +36,10 @@
     </div>
   </div>
 
+  <!-- Gráficos analíticos -->
   <div class="row g-3 mb-4">
     <div class="col-lg-6">
-      <div class="card h-100">
+      <div class="card h-100 border-0 shadow-sm">
         <div class="card-body">
           <h5 class="card-title mb-3">Falhas Mais Recorrentes</h5>
           <ul class="list-group list-group-flush">
@@ -55,14 +57,14 @@
     </div>
 
     <div class="col-lg-6">
-      <div class="card h-100">
+      <div class="card h-100 border-0 shadow-sm">
         <div class="card-body">
           <h5 class="card-title mb-3">Perguntas Repetidamente Problemáticas</h5>
           <ul class="list-group list-group-flush">
             {% for item in recurring_questions %}
             <li class="list-group-item d-flex justify-content-between align-items-center px-0">
-              <span class="me-3 text-truncate">{{ item.question }}</span>
-              <span class="badge bg-secondary rounded-pill">{{ item.count }}</span>
+              <span class="me-3 text-truncate" style="max-width: 300px;" title="{{ item.question }}">{{ item.question }}</span>
+              <span class="badge bg-secondary rounded-pill">{{ item.count }}x</span>
             </li>
             {% else %}
             <li class="list-group-item px-0 text-muted">Sem repetições relevantes até o momento.</li>
@@ -73,7 +75,8 @@
     </div>
   </div>
 
-  <div class="card">
+  <!-- Listagem detalhada -->
+  <div class="card border-0 shadow-sm">
     <div class="card-body">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h5 class="card-title mb-0">Listagem de Respostas com 👎</h5>
@@ -82,31 +85,70 @@
 
       <div class="table-responsive">
         <table class="table table-hover align-middle">
-          <thead>
+          <thead class="table-light">
             <tr>
-              <th>#</th>
-              <th>Pergunta</th>
-              <th>Resposta anterior</th>
-              <th>Falha provável</th>
-              <th>Resposta revisada</th>
-              <th>Quando</th>
+              <th style="width: 40px;">#</th>
+              <th style="width: 220px;">Pergunta do usuário</th>
+              <th style="width: 280px;">Resposta do chatbot</th>
+              <th style="width: 100px;">Falha provável</th>
+              <th>Comentário do usuário</th>
+              <th style="width: 110px;">Quando</th>
             </tr>
           </thead>
           <tbody>
             {% for feedback in feedbacks %}
+            {% set parsed = parse_feedback_comment(feedback) %}
+            {% set row_id = "row-" ~ feedback.id %}
             <tr>
-              <td>{{ loop.index + ((pagination.page - 1) * pagination.per_page) }}</td>
-              <td style="max-width: 260px; white-space: normal;">{{ feedback.question or '-' }}</td>
-              <td style="max-width: 320px; white-space: normal;">{{ feedback.answer or '-' }}</td>
+              <td class="text-muted small">{{ loop.index + ((pagination.page - 1) * pagination.per_page) }}</td>
+
+              <td style="max-width: 220px;">
+                <span class="d-block text-truncate" title="{{ feedback.question or '' }}" style="max-width: 200px;">
+                  {{ feedback.question or '-' }}
+                </span>
+              </td>
+
+              <td style="max-width: 280px;">
+                <span class="d-block" style="max-width: 260px; max-height: 72px; overflow: hidden; white-space: pre-wrap; font-size: 0.82rem;">
+                  {{ (feedback.answer or '-')[:200] }}{% if (feedback.answer or '') | length > 200 %}…{% endif %}
+                </span>
+              </td>
+
               <td>
                 <span class="badge bg-warning text-dark">{{ classify_feedback_failure(feedback) }}</span>
               </td>
-              <td style="max-width: 320px; white-space: normal;">{{ feedback.comment or '-' }}</td>
-              <td>{{ feedback.updated_at.strftime('%d/%m/%Y %H:%M') if feedback.updated_at else '-' }}</td>
+
+              <td>
+                {% if parsed.user_comment %}
+                  <p class="mb-1 small" style="white-space: pre-wrap;">{{ parsed.user_comment }}</p>
+                {% else %}
+                  <span class="text-muted small fst-italic">Sem comentário</span>
+                {% endif %}
+
+                {% if parsed.conversation_history %}
+                <div class="mt-1">
+                  <button class="btn btn-link btn-sm p-0 text-secondary"
+                          type="button"
+                          data-bs-toggle="collapse"
+                          data-bs-target="#hist-{{ feedback.id }}"
+                          aria-expanded="false">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                    Ver histórico da conversa
+                  </button>
+                  <div class="collapse mt-2" id="hist-{{ feedback.id }}">
+                    <pre class="bg-light rounded p-2 small" style="max-height: 260px; overflow-y: auto; white-space: pre-wrap; font-size: 0.75rem;">{{ parsed.conversation_history }}</pre>
+                  </div>
+                </div>
+                {% endif %}
+              </td>
+
+              <td class="text-muted small" style="white-space: nowrap;">
+                {{ feedback.updated_at.strftime('%d/%m/%Y %H:%M') if feedback.updated_at else '-' }}
+              </td>
             </tr>
             {% else %}
             <tr>
-              <td colspan="6" class="text-center">Sem respostas avaliadas como não úteis.</td>
+              <td colspan="6" class="text-center text-muted py-4">Sem respostas avaliadas como não úteis.</td>
             </tr>
             {% endfor %}
           </tbody>

--- a/apps/templates/home/index.html
+++ b/apps/templates/home/index.html
@@ -40,6 +40,26 @@
   </div>
 </div>
 
+<!-- Modal de feedback negativo -->
+<div id="feedback-modal-overlay" class="feedback-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="feedback-modal-title" style="display:none;">
+  <div class="feedback-modal">
+    <div class="feedback-modal-header">
+      <span id="feedback-modal-title" class="feedback-modal-title">O que houve com esta resposta?</span>
+      <button type="button" id="feedback-modal-close" class="feedback-modal-close" aria-label="Fechar">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+    <div class="feedback-modal-body">
+      <p class="feedback-modal-desc">Seu comentário nos ajuda a melhorar o chatbot. Descreva o problema com a resposta acima.</p>
+      <textarea id="feedback-modal-text" class="feedback-modal-textarea" rows="4" placeholder="Ex: A resposta estava incorreta, o horário informado não bate com o que tenho em mãos..." maxlength="1000"></textarea>
+      <div class="feedback-modal-charcount"><span id="feedback-modal-chars">0</span>/1000</div>
+    </div>
+    <div class="feedback-modal-footer">
+      <button type="button" id="feedback-modal-cancel" class="feedback-modal-btn feedback-modal-btn-cancel">Cancelar</button>
+      <button type="button" id="feedback-modal-submit" class="feedback-modal-btn feedback-modal-btn-submit">Enviar feedback</button>
+    </div>
+  </div>
+</div>
 
 {% endblock content %}
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -120,7 +120,7 @@ class TestChatbotRoutes(unittest.TestCase):
         bot_payload = next(item for item in messages if item["sender"] == "bot")
         self.assertEqual(bot_payload["feedback_rating"], "up")
 
-    def test_feedback_down_gera_resposta_revisada(self):
+    def test_feedback_down_salva_comentario_e_historico(self):
         with self.app.app_context():
             user_message = ChatMessage(
                 user_id=None,
@@ -139,31 +139,35 @@ class TestChatbotRoutes(unittest.TestCase):
             db.session.commit()
             bot_id = bot_message.id
 
-        with patch("apps.core.melhorar_resposta_com_feedback") as mock_improve:
-            mock_improve.return_value = {
-                "answer": "O Regimento Interno organiza o funcionamento institucional e define regras de atuação.",
-                "sources": [],
-                "docs": [],
-                "has_rag_context": True,
-                "status": "success",
-            }
-            feedback_response = self.client.post(
-                "/chatbot/feedback",
-                json={"bot_message_id": bot_id, "rating": "down"},
-            )
+        feedback_response = self.client.post(
+            "/chatbot/feedback",
+            json={
+                "bot_message_id": bot_id,
+                "rating": "down",
+                "user_comment": "A resposta estava errada, o regimento tem essa informação.",
+            },
+        )
 
         self.assertEqual(feedback_response.status_code, 200)
         payload = feedback_response.get_json()
-        self.assertIn("revised_response", payload)
-        self.assertIn("Resposta revisada", payload["revised_response"])
+        self.assertIn("ok", payload)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["rating"], "down")
+        # Não deve mais gerar resposta revisada automaticamente
+        self.assertNotIn("revised_response", payload)
 
+        import json as _json
         with self.app.app_context():
             saved_feedback = ChatFeedback.query.filter_by(bot_message_id=bot_id).first()
             self.assertIsNotNone(saved_feedback)
             self.assertEqual(saved_feedback.rating, "down")
-            self.assertIn("Resposta revisada", saved_feedback.comment or "")
-            revised_messages = ChatMessage.query.filter_by(thread_id=self.thread_id, sender="bot").all()
-            self.assertEqual(len(revised_messages), 2)
+            # comment deve ser JSON com user_comment e conversation_history
+            comment_data = _json.loads(saved_feedback.comment or "{}")
+            self.assertIn("A resposta estava errada", comment_data.get("user_comment", ""))
+            self.assertIn("conversation_history", comment_data)
+            # Não deve ter criado mensagem bot revisada
+            bot_messages = ChatMessage.query.filter_by(thread_id=self.thread_id, sender="bot").all()
+            self.assertEqual(len(bot_messages), 1)
 
     def test_admin_feedbacks_lista_respostas_negativas(self):
         with self.app.app_context():


### PR DESCRIPTION
ANTES: clicar em 👎 → sistema reformulava a resposta automaticamente → salvava no banco
AGORA: clicar em 👎 → abre modal para o usuário descrever o problema → salva comentário + histórico completo → sem auto-revisão

Mudanças:

Frontend (index.html + index-chat.js + index-chat.css):
- Modal de feedback com textarea, contador de caracteres e animações
- Botão 👎 abre o modal; usuário descreve o que houve
- Botão 👍 continua enviando diretamente (sem modal)
- Após envio: "Obrigado pelo feedback!" por 3s, sem resposta revisada na UI
- Fecha ao clicar fora, no X ou pressionar Esc

Backend (feedback_routes.py + feedback_service.py):
- Aceita user_comment no payload
- Remove toda a lógica de melhorar_resposta_com_feedback
- Salva no campo comment como JSON: {user_comment, conversation_history}
- Captura o histórico completo da thread para diagnóstico de falhas

Dashboard admin (admin_routes.py + feedbacks.html):
- Card "Revisadas automaticamente" → "Com comentário do usuário"
- Classificação de falhas usa palavras-chave do comentário do usuário
- Tabela: coluna "Resposta revisada" → "Comentário do usuário"
- Histórico da conversa expansível por linha (collapse)
- Função _parse_feedback_comment() para ler o JSON do campo comment

Testes (test_request.py):
- test_feedback_down_gera_resposta_revisada → test_feedback_down_salva_comentario_e_historico
- Valida novo comportamento: sem revised_response, comment em JSON, sem msg bot extra