### PR TITLE
feat: dashboard de feedbacks com layout adaptativo e modal de histórico

### DIFF
--- a/apps/templates/admin/feedbacks.html
+++ b/apps/templates/admin/feedbacks.html
@@ -2,163 +2,294 @@
 {% block title %} Feedbacks Negativos {% endblock title %}
 
 {% block content %}
-<div class="container py-4">
-  <div class="d-flex justify-content-between align-items-center mb-3">
+<style>
+/* ── Layout geral ──────────────────────────────────────── */
+.fb-page { max-width: 1200px; margin: 0 auto; padding: 28px 16px 48px; }
+.fb-page h3 { font-size: 1.25rem; font-weight: 700; color: #1f2937; }
+
+/* ── Cards de resumo ───────────────────────────────────── */
+.fb-stat-card { border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px 22px; background: #fff; }
+.fb-stat-label { font-size: 0.78rem; color: #6b7280; margin-bottom: 6px; }
+.fb-stat-value { font-size: 2rem; font-weight: 700; line-height: 1; }
+
+/* ── Lista analítica ───────────────────────────────────── */
+.fb-analytics-card { border: 1px solid #e5e7eb; border-radius: 12px; background: #fff; overflow: hidden; }
+.fb-analytics-card .card-title { font-size: 0.9rem; font-weight: 600; padding: 16px 20px 0; margin: 0; color: #374151; }
+.fb-analytics-card ul { list-style: none; margin: 0; padding: 8px 0 4px; }
+.fb-analytics-card li { display: flex; justify-content: space-between; align-items: center;
+  padding: 9px 20px; font-size: 0.83rem; border-top: 1px solid #f3f4f6; }
+.fb-analytics-card li:first-child { border-top: none; }
+
+/* ── Cards de feedback ─────────────────────────────────── */
+.fb-list { display: flex; flex-direction: column; gap: 14px; }
+
+.fb-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+}
+.fb-card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  background: #f9fafb;
+  border-bottom: 1px solid #f0f0f0;
+  flex-wrap: wrap;
+}
+.fb-card-index { font-size: 0.75rem; color: #9ca3af; font-weight: 600; min-width: 28px; }
+.fb-card-date  { font-size: 0.75rem; color: #9ca3af; margin-left: auto; white-space: nowrap; }
+.fb-badge { font-size: 0.7rem; font-weight: 600; padding: 3px 10px; border-radius: 99px;
+  background: #fef3c7; color: #92400e; white-space: nowrap; }
+
+.fb-card-body { display: grid; grid-template-columns: 1fr 1fr; gap: 0; }
+@media (max-width: 700px) { .fb-card-body { grid-template-columns: 1fr; } }
+
+.fb-cell {
+  padding: 14px 18px;
+  border-right: 1px solid #f0f0f0;
+  border-bottom: 1px solid #f0f0f0;
+}
+.fb-cell:last-child { border-right: none; }
+.fb-cell-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: #9ca3af;
+  margin-bottom: 7px;
+}
+.fb-cell-text {
+  font-size: 0.84rem;
+  color: #374151;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+}
+.fb-cell-text.muted { color: #9ca3af; font-style: italic; }
+
+.fb-cell-full { grid-column: 1 / -1; }
+
+/* "Ver mais" para textos longos */
+.fb-expandable { position: relative; }
+.fb-expandable .fb-text-inner { max-height: 110px; overflow: hidden; transition: max-height .25s ease; }
+.fb-expandable.expanded .fb-text-inner { max-height: none; }
+.fb-expand-btn {
+  display: inline-flex; align-items: center; gap: 4px; margin-top: 6px;
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-size: 0.75rem; color: #2563eb; font-weight: 500;
+}
+.fb-expand-btn:hover { text-decoration: underline; }
+.fb-expand-btn svg { transition: transform .2s; }
+.fb-expandable.expanded .fb-expand-btn svg { transform: rotate(180deg); }
+
+/* Botão histórico */
+.fb-hist-btn {
+  display: inline-flex; align-items: center; gap: 5px; margin-top: 10px;
+  background: #f3f4f6; border: 1px solid #e5e7eb; border-radius: 7px;
+  padding: 5px 12px; cursor: pointer; font-size: 0.78rem; color: #374151;
+  font-weight: 500; transition: background .15s;
+}
+.fb-hist-btn:hover { background: #e5e7eb; }
+
+/* ── Modal de histórico ────────────────────────────────── */
+.fb-hist-modal-overlay {
+  display: none; position: fixed; inset: 0; z-index: 9999;
+  background: rgba(15,23,42,.5); align-items: center; justify-content: center; padding: 16px;
+}
+.fb-hist-modal-overlay.open { display: flex; }
+.fb-hist-modal {
+  background: #fff; border-radius: 16px; width: 100%; max-width: 640px;
+  max-height: 85vh; display: flex; flex-direction: column;
+  box-shadow: 0 24px 64px rgba(15,23,42,.2);
+  animation: fbModalIn .18s ease;
+}
+@keyframes fbModalIn {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.fb-hist-modal-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 20px; border-bottom: 1px solid #e5e7eb; flex-shrink: 0;
+}
+.fb-hist-modal-head h6 { margin: 0; font-size: 0.95rem; font-weight: 700; color: #1f2937; }
+.fb-hist-close {
+  background: none; border: none; cursor: pointer; color: #6b7280;
+  padding: 4px; border-radius: 6px; display: flex; align-items: center;
+}
+.fb-hist-close:hover { background: #f3f4f6; color: #1f2937; }
+.fb-hist-modal-body { overflow-y: auto; padding: 18px 20px; flex: 1; }
+
+/* Bolhas de conversa dentro do modal */
+.fb-conv-wrap { display: flex; flex-direction: column; gap: 12px; }
+.fb-conv-msg { display: flex; flex-direction: column; max-width: 88%; gap: 3px; }
+.fb-conv-msg.user  { align-self: flex-end; align-items: flex-end; }
+.fb-conv-msg.bot   { align-self: flex-start; align-items: flex-start; }
+.fb-conv-role {
+  font-size: 0.68rem; font-weight: 600; text-transform: uppercase;
+  letter-spacing: .04em; color: #9ca3af; padding: 0 4px;
+}
+.fb-conv-bubble {
+  border-radius: 12px; padding: 10px 14px;
+  font-size: 0.84rem; line-height: 1.55; white-space: pre-wrap; word-break: break-word;
+}
+.fb-conv-msg.user  .fb-conv-bubble { background: #2563eb; color: #fff; border-bottom-right-radius: 3px; }
+.fb-conv-msg.bot   .fb-conv-bubble { background: #f3f4f6; color: #1f2937; border-bottom-left-radius: 3px; }
+.fb-conv-raw { font-size: 0.82rem; color: #374151; white-space: pre-wrap; word-break: break-word;
+  background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px 14px; }
+</style>
+
+<div class="fb-page">
+  <div class="d-flex justify-content-between align-items-center mb-4">
     <h3>Feedbacks Negativos do Chatbot</h3>
-    <a href="{{ url_for('authentication_blueprint.admin_docs') }}" class="btn btn-sm btn-link">Voltar</a>
+    <a href="{{ url_for('authentication_blueprint.admin_docs') }}" class="btn btn-sm btn-outline-secondary">← Voltar</a>
   </div>
 
   <!-- Cards de resumo -->
   <div class="row g-3 mb-4">
-    <div class="col-md-4">
-      <div class="card h-100 border-0 shadow-sm">
-        <div class="card-body">
-          <div class="text-muted small mb-1">Total de respostas com 👎</div>
-          <div class="display-6 fw-bold text-danger">{{ stats.total_down }}</div>
-        </div>
+    <div class="col-sm-4">
+      <div class="fb-stat-card">
+        <div class="fb-stat-label">Total com 👎</div>
+        <div class="fb-stat-value text-danger">{{ stats.total_down }}</div>
       </div>
     </div>
-    <div class="col-md-4">
-      <div class="card h-100 border-0 shadow-sm">
-        <div class="card-body">
-          <div class="text-muted small mb-1">Com comentário do usuário</div>
-          <div class="display-6 fw-bold text-primary">{{ stats.with_comment_count }}</div>
-        </div>
+    <div class="col-sm-4">
+      <div class="fb-stat-card">
+        <div class="fb-stat-label">Com comentário do usuário</div>
+        <div class="fb-stat-value text-primary">{{ stats.with_comment_count }}</div>
       </div>
     </div>
-    <div class="col-md-4">
-      <div class="card h-100 border-0 shadow-sm">
-        <div class="card-body">
-          <div class="text-muted small mb-1">Falha mais recorrente</div>
-          <div class="fw-semibold mt-2">{{ stats.top_failure }}</div>
-        </div>
+    <div class="col-sm-4">
+      <div class="fb-stat-card">
+        <div class="fb-stat-label">Falha mais recorrente</div>
+        <div class="fw-semibold mt-2" style="font-size:.9rem;color:#374151;">{{ stats.top_failure }}</div>
       </div>
     </div>
   </div>
 
-  <!-- Gráficos analíticos -->
+  <!-- Análise -->
   <div class="row g-3 mb-4">
     <div class="col-lg-6">
-      <div class="card h-100 border-0 shadow-sm">
-        <div class="card-body">
-          <h5 class="card-title mb-3">Falhas Mais Recorrentes</h5>
-          <ul class="list-group list-group-flush">
-            {% for item in recurrent_failures %}
-            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
-              <span>{{ item.label }}</span>
-              <span class="badge bg-danger rounded-pill">{{ item.count }}</span>
-            </li>
-            {% else %}
-            <li class="list-group-item px-0 text-muted">Sem feedbacks negativos registrados.</li>
-            {% endfor %}
-          </ul>
-        </div>
+      <div class="fb-analytics-card">
+        <div class="card-title">Falhas Mais Recorrentes</div>
+        <ul>
+          {% for item in recurrent_failures %}
+          <li>
+            <span>{{ item.label }}</span>
+            <span class="badge bg-danger rounded-pill">{{ item.count }}</span>
+          </li>
+          {% else %}
+          <li style="color:#9ca3af;font-style:italic;">Sem feedbacks negativos registrados.</li>
+          {% endfor %}
+        </ul>
       </div>
     </div>
-
     <div class="col-lg-6">
-      <div class="card h-100 border-0 shadow-sm">
-        <div class="card-body">
-          <h5 class="card-title mb-3">Perguntas Repetidamente Problemáticas</h5>
-          <ul class="list-group list-group-flush">
-            {% for item in recurring_questions %}
-            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
-              <span class="me-3 text-truncate" style="max-width: 300px;" title="{{ item.question }}">{{ item.question }}</span>
-              <span class="badge bg-secondary rounded-pill">{{ item.count }}x</span>
-            </li>
-            {% else %}
-            <li class="list-group-item px-0 text-muted">Sem repetições relevantes até o momento.</li>
-            {% endfor %}
-          </ul>
+      <div class="fb-analytics-card">
+        <div class="card-title">Perguntas Repetidamente Problemáticas</div>
+        <ul>
+          {% for item in recurring_questions %}
+          <li>
+            <span style="flex:1;margin-right:12px;word-break:break-word;">{{ item.question }}</span>
+            <span class="badge bg-secondary rounded-pill" style="flex-shrink:0;">{{ item.count }}x</span>
+          </li>
+          {% else %}
+          <li style="color:#9ca3af;font-style:italic;">Sem repetições relevantes até o momento.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- Listagem de feedbacks (cards) -->
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 style="font-size:.95rem;font-weight:700;color:#1f2937;margin:0;">Listagem de Respostas com 👎</h5>
+    <span class="text-muted small">Mais recentes primeiro</span>
+  </div>
+
+  {% if feedbacks %}
+  <div class="fb-list">
+    {% for feedback in feedbacks %}
+    {% set parsed = parse_feedback_comment(feedback) %}
+    {% set idx = loop.index + ((pagination.page - 1) * pagination.per_page) %}
+    <div class="fb-card">
+      <!-- Cabeçalho do card -->
+      <div class="fb-card-header">
+        <span class="fb-card-index">#{{ idx }}</span>
+        <span class="fb-badge">{{ classify_feedback_failure(feedback) }}</span>
+        {% if parsed.conversation_history %}
+        <button class="fb-hist-btn"
+                type="button"
+                data-history="{{ parsed.conversation_history | e }}"
+                onclick="openHistModal(this)">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          Ver histórico da conversa
+        </button>
+        {% endif %}
+        <span class="fb-card-date">{{ feedback.updated_at.strftime('%d/%m/%Y %H:%M') if feedback.updated_at else '-' }}</span>
+      </div>
+
+      <!-- Corpo do card: pergunta | resposta -->
+      <div class="fb-card-body">
+        <div class="fb-cell">
+          <div class="fb-cell-label">Pergunta do usuário</div>
+          {% set q = feedback.question or '' %}
+          {% if q | length > 300 %}
+          <div class="fb-expandable" id="exp-q-{{ feedback.id }}">
+            <div class="fb-text-inner fb-cell-text">{{ q }}</div>
+            <button class="fb-expand-btn" onclick="toggleExpand('exp-q-{{ feedback.id }}', this)">
+              <span>Ver mais</span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+          </div>
+          {% elif q %}
+          <div class="fb-cell-text">{{ q }}</div>
+          {% else %}
+          <div class="fb-cell-text muted">-</div>
+          {% endif %}
+        </div>
+
+        <div class="fb-cell" style="border-right:none;">
+          <div class="fb-cell-label">Resposta do chatbot</div>
+          {% set a = feedback.answer or '' %}
+          {% if a | length > 300 %}
+          <div class="fb-expandable" id="exp-a-{{ feedback.id }}">
+            <div class="fb-text-inner fb-cell-text">{{ a }}</div>
+            <button class="fb-expand-btn" onclick="toggleExpand('exp-a-{{ feedback.id }}', this)">
+              <span>Ver mais</span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+          </div>
+          {% elif a %}
+          <div class="fb-cell-text">{{ a }}</div>
+          {% else %}
+          <div class="fb-cell-text muted">-</div>
+          {% endif %}
+        </div>
+
+        <!-- Comentário (full width) -->
+        <div class="fb-cell fb-cell-full" style="border-right:none;border-bottom:none;">
+          <div class="fb-cell-label">Comentário do usuário</div>
+          {% if parsed.user_comment %}
+          <div class="fb-cell-text">{{ parsed.user_comment }}</div>
+          {% else %}
+          <div class="fb-cell-text muted">Nenhum comentário enviado.</div>
+          {% endif %}
         </div>
       </div>
     </div>
+    {% endfor %}
   </div>
-
-  <!-- Listagem detalhada -->
-  <div class="card border-0 shadow-sm">
-    <div class="card-body">
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <h5 class="card-title mb-0">Listagem de Respostas com 👎</h5>
-        <span class="text-muted small">Mais recentes primeiro</span>
-      </div>
-
-      <div class="table-responsive">
-        <table class="table table-hover align-middle">
-          <thead class="table-light">
-            <tr>
-              <th style="width: 40px;">#</th>
-              <th style="width: 220px;">Pergunta do usuário</th>
-              <th style="width: 280px;">Resposta do chatbot</th>
-              <th style="width: 100px;">Falha provável</th>
-              <th>Comentário do usuário</th>
-              <th style="width: 110px;">Quando</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for feedback in feedbacks %}
-            {% set parsed = parse_feedback_comment(feedback) %}
-            {% set row_id = "row-" ~ feedback.id %}
-            <tr>
-              <td class="text-muted small">{{ loop.index + ((pagination.page - 1) * pagination.per_page) }}</td>
-
-              <td style="max-width: 220px;">
-                <span class="d-block text-truncate" title="{{ feedback.question or '' }}" style="max-width: 200px;">
-                  {{ feedback.question or '-' }}
-                </span>
-              </td>
-
-              <td style="max-width: 280px;">
-                <span class="d-block" style="max-width: 260px; max-height: 72px; overflow: hidden; white-space: pre-wrap; font-size: 0.82rem;">
-                  {{ (feedback.answer or '-')[:200] }}{% if (feedback.answer or '') | length > 200 %}…{% endif %}
-                </span>
-              </td>
-
-              <td>
-                <span class="badge bg-warning text-dark">{{ classify_feedback_failure(feedback) }}</span>
-              </td>
-
-              <td>
-                {% if parsed.user_comment %}
-                  <p class="mb-1 small" style="white-space: pre-wrap;">{{ parsed.user_comment }}</p>
-                {% else %}
-                  <span class="text-muted small fst-italic">Sem comentário</span>
-                {% endif %}
-
-                {% if parsed.conversation_history %}
-                <div class="mt-1">
-                  <button class="btn btn-link btn-sm p-0 text-secondary"
-                          type="button"
-                          data-bs-toggle="collapse"
-                          data-bs-target="#hist-{{ feedback.id }}"
-                          aria-expanded="false">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-                    Ver histórico da conversa
-                  </button>
-                  <div class="collapse mt-2" id="hist-{{ feedback.id }}">
-                    <pre class="bg-light rounded p-2 small" style="max-height: 260px; overflow-y: auto; white-space: pre-wrap; font-size: 0.75rem;">{{ parsed.conversation_history }}</pre>
-                  </div>
-                </div>
-                {% endif %}
-              </td>
-
-              <td class="text-muted small" style="white-space: nowrap;">
-                {{ feedback.updated_at.strftime('%d/%m/%Y %H:%M') if feedback.updated_at else '-' }}
-              </td>
-            </tr>
-            {% else %}
-            <tr>
-              <td colspan="6" class="text-center text-muted py-4">Sem respostas avaliadas como não úteis.</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
+  {% else %}
+  <div class="text-center text-muted py-5">
+    <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true" style="opacity:.4;margin-bottom:12px;display:block;margin-inline:auto;"><path d="M9 11V5.8c0-.9.3-1.7.9-2.4L11.2 2l1 1c.5.5.8 1.2.8 1.9V8h4.4c1.1 0 1.9 1 1.7 2.1l-1 6.2c-.2 1-1 1.7-2 1.7H9"/><path d="M5 10h2a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1Z"/></svg>
+    Sem respostas avaliadas como não úteis.
   </div>
+  {% endif %}
 
-  {% if pagination %}
-  <nav aria-label="paginação" class="mt-3">
+  {% if pagination and pagination.pages > 1 %}
+  <nav aria-label="paginação" class="mt-4">
     <ul class="pagination">
       {% if pagination.has_prev %}
       <li class="page-item"><a class="page-link" href="{{ url_for('authentication_blueprint.admin_feedbacks', page=pagination.prev_num) }}">Anterior</a></li>
@@ -171,4 +302,109 @@
   </nav>
   {% endif %}
 </div>
+
+<!-- Modal de histórico da conversa (único, reutilizado) -->
+<div class="fb-hist-modal-overlay" id="fb-hist-overlay" onclick="closeHistModal(event)">
+  <div class="fb-hist-modal" role="dialog" aria-modal="true" aria-labelledby="fb-hist-title">
+    <div class="fb-hist-modal-head">
+      <h6 id="fb-hist-title">Histórico da Conversa</h6>
+      <button class="fb-hist-close" onclick="closeHistModalDirect()" aria-label="Fechar">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+    <div class="fb-hist-modal-body" id="fb-hist-body">
+      <!-- preenchido via JS -->
+    </div>
+  </div>
+</div>
+
+<script>
+/* ── "Ver mais / Ver menos" ───────────────────────────── */
+function toggleExpand(id, btn) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const expanded = el.classList.toggle('expanded');
+  const label = btn.querySelector('span');
+  if (label) label.textContent = expanded ? 'Ver menos' : 'Ver mais';
+}
+
+/* ── Modal de histórico ───────────────────────────────── */
+function openHistModal(btn) {
+  const raw = btn.getAttribute('data-history') || '';
+  const body = document.getElementById('fb-hist-body');
+  body.innerHTML = renderConversation(raw);
+  document.getElementById('fb-hist-overlay').classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeHistModal(event) {
+  if (event.target === document.getElementById('fb-hist-overlay')) closeHistModalDirect();
+}
+
+function closeHistModalDirect() {
+  document.getElementById('fb-hist-overlay').classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape') closeHistModalDirect();
+});
+
+/* ── Renderiza histórico em bolhas de conversa ─────────── */
+function renderConversation(text) {
+  if (!text || !text.trim()) return '<p class="text-muted small">Sem histórico disponível.</p>';
+
+  const lines = text.split('\n');
+  const messages = [];
+  let current = null;
+
+  for (const line of lines) {
+    const userMatch  = line.match(/^Usuário:\s*(.*)/i);
+    const botMatch   = line.match(/^Assistente:\s*(.*)/i);
+
+    if (userMatch) {
+      if (current) messages.push(current);
+      current = { role: 'user', text: userMatch[1] };
+    } else if (botMatch) {
+      if (current) messages.push(current);
+      current = { role: 'bot', text: botMatch[1] };
+    } else if (current) {
+      current.text += '\n' + line;
+    }
+  }
+  if (current) messages.push(current);
+
+  if (messages.length === 0) {
+    // Formato não reconhecido — exibe como texto pré-formatado
+    const pre = document.createElement('pre');
+    pre.className = 'fb-conv-raw';
+    pre.textContent = text;
+    const div = document.createElement('div');
+    div.appendChild(pre);
+    return div.innerHTML;
+  }
+
+  const wrap = document.createElement('div');
+  wrap.className = 'fb-conv-wrap';
+
+  for (const msg of messages) {
+    const msgEl = document.createElement('div');
+    msgEl.className = 'fb-conv-msg ' + (msg.role === 'user' ? 'user' : 'bot');
+
+    const roleEl = document.createElement('div');
+    roleEl.className = 'fb-conv-role';
+    roleEl.textContent = msg.role === 'user' ? 'Usuário' : 'Assistente';
+
+    const bubbleEl = document.createElement('div');
+    bubbleEl.className = 'fb-conv-bubble';
+    bubbleEl.textContent = (msg.text || '').trim();
+
+    msgEl.appendChild(roleEl);
+    msgEl.appendChild(bubbleEl);
+    wrap.appendChild(msgEl);
+  }
+
+  return wrap.outerHTML;
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
- Substituiu tabela por cards por feedback: cada linha é um card que exibe o texto completo sem cortes fixos de altura ou largura
- Textos longos (>300 chars) mostram os primeiros ~110px com botão "Ver mais / Ver menos" (expand suave via CSS max-height)
- Botão "Ver histórico da conversa" abre um modal centralizado com visualização em bolhas de chat (Usuário azul à direita, Assistente cinza à esquerda)
- O histórico é parseado linha a linha por prefixo "Usuário:" / "Assistente:"; formatos não reconhecidos são exibidos como texto pré-formatado
- Modal: fecha com X, clique fora ou Esc; bloqueia scroll do body enquanto aberto
- Único modal reutilizável (não um por row); preenchido via JS ao abrir