### PR TITLE
feat: modo prod controlado por ENV — chatbot público sem login e UI m…

### DIFF
--- a/apps/authentication/routes/auth_routes.py
+++ b/apps/authentication/routes/auth_routes.py
@@ -3,7 +3,7 @@
 Rotas de autenticacao e registro.
 """
 
-from flask import redirect, render_template, request, url_for
+from flask import current_app, redirect, render_template, request, url_for
 from flask_login import current_user, login_user, logout_user
 
 from apps import db
@@ -21,9 +21,11 @@ def health():
 
 @blueprint.route("/")
 def route_default():
+    # Em prod, todos vão direto ao chatbot sem precisar fazer login
+    if current_app.config.get('APP_ENV') == 'prod':
+        return redirect(url_for("home_blueprint.index"))
     if current_user.is_authenticated:
         return redirect(url_for("home_blueprint.index"))
-    # Redireciona para login por padrão, sem precisar de ?ui=1
     return redirect(url_for("authentication_blueprint.login"))
 
 @blueprint.route("/login", methods=["GET", "POST"])

--- a/apps/config.py
+++ b/apps/config.py
@@ -12,6 +12,10 @@ class Config(object):
     # Assets Management
     ASSETS_ROOT = os.getenv('ASSETS_ROOT', '/static/assets')
 
+    # Ambiente: 'dev' mantém login obrigatório e UI completa.
+    # 'prod' libera o chatbot sem login e exibe UI mínima (sem sidebar/navbar).
+    APP_ENV = os.getenv('ENV', 'dev').strip().lower()
+
     # Set up the App SECRET_KEY
     SECRET_KEY  = os.getenv('SECRET_KEY', None)
     if not SECRET_KEY:

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -1,33 +1,30 @@
 # -*- encoding: utf-8 -*-
-"""
-Copyright (c) 2019 - present AppSeed.us
-"""
-
 from apps.home import blueprint
-from flask import render_template, request
-from flask_login import login_required
+from flask import current_app, redirect, render_template, request, url_for
+from flask_login import current_user
 from jinja2 import TemplateNotFound
 
 
 @blueprint.route('/index')
-@login_required
 def index():
+    # Em prod, qualquer pessoa acessa sem login.
+    # Em dev, exige autenticação.
+    if current_app.config.get('APP_ENV') != 'prod' and not current_user.is_authenticated:
+        return redirect(url_for('authentication_blueprint.login'))
     return render_template('home/index.html', segment='index')
 
 
 @blueprint.route('/<template>')
-@login_required
 def route_template(template):
+    # Rotas genéricas sempre exigem login (são páginas administrativas)
+    if not current_user.is_authenticated:
+        return redirect(url_for('authentication_blueprint.login'))
 
     try:
-
         if not template.endswith('.html'):
             template += '.html'
 
-        # Detect the current page
         segment = get_segment(request)
-
-        # Serve the file (if exists) from app/templates/home/FILE.html
         return render_template("home/" + template, segment=segment)
 
     except TemplateNotFound:
@@ -37,17 +34,11 @@ def route_template(template):
         return render_template('home/page-500.html'), 500
 
 
-# Helper - Extract current page name from request
 def get_segment(request):
-
     try:
-
         segment = request.path.split('/')[-1]
-
         if segment == '':
             segment = 'index'
-
         return segment
-
     except:
         return None

--- a/apps/static/assets/js/index-chat.js
+++ b/apps/static/assets/js/index-chat.js
@@ -8,6 +8,9 @@ const sidebarChatToggle = document.getElementById('sidebar-chat-toggle');
 const sidebarChatDropdown = document.getElementById('sidebar-chat-dropdown');
 const sidebarChatItem = document.querySelector('.sidebar-chat-item');
 
+// Em prod: sem histórico de conversas, sem raciocínio, sem sidebar
+const IS_PROD = (window.CHAT_MODE === 'prod');
+
 let activeThreadId = null;
 
 if (chatContainer && document.body) {
@@ -579,7 +582,8 @@ async function deleteConversation(threadId) {
 }
 
 function appendThoughtsDropdown(messageElement, thoughtsText) {
-  if (!thoughtsText) return;
+  // Em prod não exibe o raciocínio interno para usuários externos
+  if (IS_PROD || !thoughtsText) return;
 
   const dropdown = document.createElement('details');
   dropdown.className = 'thoughts-dropdown';
@@ -623,7 +627,9 @@ form.addEventListener('submit', async (e) => {
     if (data.thoughts) {
       appendThoughtsDropdown(finalMsg, data.thoughts);
     }
-    await refreshConversationList();
+    if (!IS_PROD) {
+      await refreshConversationList();
+    }
   } catch (error) {
     chatBox.removeChild(loadingMsg);
     createMessageBubble('bot', '❌ Erro ao se comunicar com o servidor.');
@@ -660,7 +666,13 @@ window.addEventListener('resize', syncNavbarHeightVar);
 document.addEventListener('DOMContentLoaded', async () => {
   syncNavbarHeightVar();
   setTimeout(syncNavbarHeightVar, 250);
-  await refreshConversationList();
-  await loadConversation();
-  setSidebarDropdownOpen(true);
+
+  if (IS_PROD) {
+    // Modo prod: começa sempre com chat limpo, sem carregar histórico ou sidebar
+    setInitialState(true);
+  } else {
+    await refreshConversationList();
+    await loadConversation();
+    setSidebarDropdownOpen(true);
+  }
 });

--- a/apps/templates/home/index.html
+++ b/apps/templates/home/index.html
@@ -1,4 +1,4 @@
-{% extends "layouts/base.html" %}
+{% extends "layouts/base-prod.html" if (config.APP_ENV == 'prod' and not current_user.is_authenticated) else "layouts/base.html" %}
 
 {% block title %} Chatbot IFPI {% endblock title %}
 
@@ -65,8 +65,10 @@
 
 {% block javascripts %}
 <script src="https://cdn.jsdelivr.net/npm/markdown-it@13.0.1/dist/markdown-it.min.js"></script>
- <script>
+<script>
   const logoUrl = "{{ url_for('static', filename='assets/images/logo.png') }}";
+  // Modo da aplicação: 'prod' = sem histórico, sem raciocínio, sem sidebar
+  window.CHAT_MODE = "{{ config.APP_ENV if config.APP_ENV == 'prod' else 'dev' }}";
 </script>
- <script src="{{ config.ASSETS_ROOT }}/js/index-chat.js"></script>
+<script src="{{ config.ASSETS_ROOT }}/js/index-chat.js"></script>
 {% endblock javascripts %}

--- a/apps/templates/layouts/base-prod.html
+++ b/apps/templates/layouts/base-prod.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>IFPIA – {% block title %}Chatbot{% endblock %}</title>
+  <link type="text/css" href="{{ config.ASSETS_ROOT }}/css/index.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  {% block stylesheets %}{% endblock %}
+  <style>
+    /* Layout limpo sem sidebar/navbar para usuários externos */
+    body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; background: #F8FAFC; }
+    .prod-shell { display: flex; flex-direction: column; height: 100vh; }
+    .prod-topbar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 20px; height: 52px; background: #fff;
+      border-bottom: 1px solid rgba(15,23,42,.08); flex-shrink: 0;
+    }
+    .prod-topbar-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+    .prod-topbar-brand img { height: 28px; }
+    .prod-topbar-name { font-size: .9rem; font-weight: 700; color: #1f2937; }
+    .prod-topbar-sub  { font-size: .72rem; color: #6b7280; }
+    .prod-content { flex: 1; overflow: hidden; }
+  </style>
+</head>
+<body>
+  <div class="prod-shell">
+    <header class="prod-topbar">
+      <a class="prod-topbar-brand" href="{{ url_for('home_blueprint.index') }}">
+        <img src="{{ config.ASSETS_ROOT }}/images/logo.png" alt="Logo IFPI">
+        <div>
+          <div class="prod-topbar-name">Chatbot IFPI</div>
+          <div class="prod-topbar-sub">Assistente Institucional</div>
+        </div>
+      </a>
+    </header>
+
+    <main class="prod-content">
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+
+  {% block javascripts %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
…ínima

Variável de ambiente ENV=prod ativa o modo de teste externo:

Roteamento:
- / redireciona diretamente para /index sem exigir login
- /index não exige @login_required quando APP_ENV=prod
- Rotas /admin/* continuam exigindo login (admin_required mantido)

Layout (ENV=prod, usuário não autenticado):
- index.html estende base-prod.html em vez de base.html
- base-prod.html: topbar minimalista (logo + nome), sem sidebar, sem navbar
- Nenhum link para login, perfil, histórico ou painel admin exposto

Comportamento JS (IS_PROD=true via window.CHAT_MODE):
- DOMContentLoaded: não carrega histórico nem refreshConversationList
- Após enviar mensagem: não chama refreshConversationList
- appendThoughtsDropdown retorna cedo (raciocínio interno oculto)
- Chat da sessão atual funciona normalmente

Quando admin está logado (ENV=prod mas autenticado):
- index.html estende base.html normalmente (full sidebar + nav)
- Acesso a /admin/docs, /admin/feedbacks, etc. funciona como sempre

Dev (ENV=dev ou ausente):
- Comportamento 100% idêntico ao atual, sem nenhuma alteração