### PR TITLE
feat: aba admin para visualizar conversas de usuários externos

### DIFF
--- a/apps/authentication/routes/admin_routes.py
+++ b/apps/authentication/routes/admin_routes.py
@@ -18,11 +18,13 @@ from apps.authentication import blueprint
 from apps.authentication.decorators import admin_required
 from apps.authentication import (
     ChatFeedback,
+    ChatMessage,
     DocumentoOficial,
     DocumentoVersao,
     LogProcessamento,
 )
 from apps.core.documents.services.revision_orchestrator import executar_revisao_documento
+from apps.core.chat.services.serialization_service import build_conversation_summaries
 
 
 def _normalize_feedback_text(value: str) -> str:
@@ -302,3 +304,90 @@ def admin_revisar_doc(doc_id):
         flash(f"Erro crítico ao executar revisão: {str(e)}", "danger")
 
     return redirect(request.referrer or url_for("authentication_blueprint.admin_docs"))
+
+
+@blueprint.route("/admin/conversations")
+@login_required
+@admin_required
+def admin_conversations():
+    """Lista todas as conversas de usuários externos (user_id IS NULL)."""
+    page = int(request.args.get("page", 1))
+    per_page = 30
+
+    # Busca todos os thread_ids distintos de mensagens anônimas, ordenados pela mais recente
+    from sqlalchemy import func
+    subq = (
+        db.session.query(
+            ChatMessage.thread_id,
+            func.max(ChatMessage.created_at).label("last_at"),
+            func.count(ChatMessage.id).label("msg_count"),
+        )
+        .filter(ChatMessage.user_id.is_(None))
+        .group_by(ChatMessage.thread_id)
+        .order_by(desc(func.max(ChatMessage.created_at)))
+    )
+
+    total_threads = subq.count()
+    thread_rows = subq.offset((page - 1) * per_page).limit(per_page).all()
+
+    # Para cada thread, busca a primeira mensagem do usuário (título) e a última mensagem (preview)
+    conversations = []
+    for row in thread_rows:
+        thread_id = row.thread_id
+        first_user_msg = (
+            ChatMessage.query
+            .filter(ChatMessage.thread_id == thread_id, ChatMessage.user_id.is_(None), ChatMessage.sender == "user")
+            .order_by(ChatMessage.created_at.asc())
+            .first()
+        )
+        last_msg = (
+            ChatMessage.query
+            .filter(ChatMessage.thread_id == thread_id, ChatMessage.user_id.is_(None))
+            .order_by(ChatMessage.created_at.desc())
+            .first()
+        )
+        conversations.append({
+            "thread_id": thread_id,
+            "title": (first_user_msg.content or "").strip()[:70] if first_user_msg else "Conversa sem mensagens",
+            "last_preview": (last_msg.content or "").strip()[:100] if last_msg else "",
+            "last_sender": last_msg.sender if last_msg else "",
+            "last_at": row.last_at,
+            "msg_count": row.msg_count,
+        })
+
+    # Paginação simples
+    total_pages = max(1, (total_threads + per_page - 1) // per_page)
+
+    return render_template(
+        "admin/conversations.html",
+        conversations=conversations,
+        page=page,
+        total_pages=total_pages,
+        total_threads=total_threads,
+    )
+
+
+@blueprint.route("/admin/conversations/<thread_id>")
+@login_required
+@admin_required
+def admin_conversation_detail(thread_id):
+    """Exibe todas as mensagens de uma conversa externa específica."""
+    messages = (
+        ChatMessage.query
+        .filter(ChatMessage.thread_id == thread_id, ChatMessage.user_id.is_(None))
+        .order_by(ChatMessage.created_at.asc(), ChatMessage.id.asc())
+        .all()
+    )
+    if not messages:
+        flash("Conversa não encontrada ou pertence a um usuário autenticado.", "warning")
+        return redirect(url_for("authentication_blueprint.admin_conversations"))
+
+    first_user_msg = next((m for m in messages if m.sender == "user"), None)
+    title = (first_user_msg.content or "").strip()[:70] if first_user_msg else thread_id
+
+    return render_template(
+        "admin/conversation_detail.html",
+        messages=messages,
+        thread_id=thread_id,
+        title=title,
+    )

--- a/apps/templates/admin/conversation_detail.html
+++ b/apps/templates/admin/conversation_detail.html
@@ -1,0 +1,197 @@
+{% extends "layouts/base.html" %}
+{% block title %} Conversa Externa {% endblock title %}
+
+{% block stylesheets %}
+<style>
+  .cd-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 28px;
+    flex-wrap: wrap;
+  }
+  .cd-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: .83rem;
+    color: #6366f1;
+    text-decoration: none;
+    padding: 5px 10px;
+    border-radius: 6px;
+    border: 1px solid #e0e7ff;
+    background: #f5f3ff;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .cd-back-btn:hover { background: #ede9fe; text-decoration: none; color: #4f46e5; }
+  .cd-title-block { flex: 1; }
+  .cd-title-block h3 {
+    margin: 0 0 4px;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #1e293b;
+    line-height: 1.35;
+  }
+  .cd-meta { font-size: .78rem; color: #94a3b8; }
+
+  /* Chat bubbles */
+  .cd-messages {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-width: 780px;
+    margin: 0 auto;
+    padding-bottom: 48px;
+  }
+  .cd-msg {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .cd-msg.user { flex-direction: row-reverse; }
+  .cd-avatar {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .8rem;
+    font-weight: 700;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+  .cd-avatar.avatar-user { background: #dbeafe; color: #1d4ed8; }
+  .cd-avatar.avatar-bot  { background: #ede9fe; color: #6d28d9; }
+  .cd-bubble {
+    max-width: 72%;
+    padding: 11px 15px;
+    border-radius: 14px;
+    font-size: .88rem;
+    line-height: 1.6;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+  .cd-msg.user .cd-bubble {
+    background: #2563eb;
+    color: #fff;
+    border-bottom-right-radius: 4px;
+  }
+  .cd-msg.bot .cd-bubble {
+    background: #f1f5f9;
+    color: #1e293b;
+    border-bottom-left-radius: 4px;
+    border: 1px solid #e2e8f0;
+  }
+  .cd-ts {
+    font-size: .68rem;
+    opacity: .55;
+    margin-top: 4px;
+    text-align: right;
+  }
+  .cd-msg.bot .cd-ts { text-align: left; }
+  .cd-msg-wrap { display: flex; flex-direction: column; }
+  .cd-msg.user .cd-msg-wrap { align-items: flex-end; }
+
+  /* Thoughts accordion */
+  .cd-thoughts-toggle {
+    font-size: .72rem;
+    color: #6366f1;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 2px 0;
+    text-decoration: underline;
+    margin-top: 4px;
+  }
+  .cd-thoughts-body {
+    background: #faf5ff;
+    border: 1px solid #e9d5ff;
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: .78rem;
+    color: #5b21b6;
+    white-space: pre-wrap;
+    margin-top: 6px;
+    max-width: 600px;
+  }
+
+  .cd-separator {
+    text-align: center;
+    font-size: .72rem;
+    color: #cbd5e1;
+    margin: 8px 0;
+    position: relative;
+  }
+  .cd-separator::before,
+  .cd-separator::after {
+    content: "";
+    display: inline-block;
+    width: 80px;
+    height: 1px;
+    background: #e2e8f0;
+    vertical-align: middle;
+    margin: 0 8px;
+  }
+</style>
+{% endblock stylesheets %}
+
+{% block content %}
+<div class="container py-4">
+
+  <div class="cd-header">
+    <a class="cd-back-btn" href="{{ url_for('authentication_blueprint.admin_conversations') }}">
+      <i class="ti-arrow-left"></i> Todas as conversas
+    </a>
+    <div class="cd-title-block">
+      <h3>{{ title }}</h3>
+      <span class="cd-meta">
+        Thread: <code>{{ thread_id }}</code> &nbsp;·&nbsp;
+        {{ messages|length }} mensagen{{ 's' if messages|length != 1 else '' }}
+      </span>
+    </div>
+  </div>
+
+  <div class="cd-messages">
+    {% for msg in messages %}
+
+    {% if loop.first or (messages[loop.index0 - 1].created_at and msg.created_at and
+        (msg.created_at - messages[loop.index0 - 1].created_at).total_seconds() > 3600) %}
+    <div class="cd-separator">{{ msg.created_at.strftime('%d/%m/%Y') if msg.created_at else '' }}</div>
+    {% endif %}
+
+    <div class="cd-msg {{ msg.sender }}">
+      <div class="cd-avatar avatar-{{ msg.sender }}">
+        {% if msg.sender == 'user' %}U{% else %}<i class="ti-face-smile" style="font-size:.75rem;"></i>{% endif %}
+      </div>
+      <div class="cd-msg-wrap">
+        <div class="cd-bubble">{{ msg.content }}</div>
+        {% if msg.created_at %}
+        <div class="cd-ts">{{ msg.created_at.strftime('%H:%M') }}</div>
+        {% endif %}
+
+        {% if msg.sender == 'bot' and msg.thoughts %}
+        <button class="cd-thoughts-toggle" onclick="toggleThoughts(this)">Ver raciocínio</button>
+        <div class="cd-thoughts-body" style="display:none;">{{ msg.thoughts }}</div>
+        {% endif %}
+      </div>
+    </div>
+
+    {% endfor %}
+  </div>
+
+</div>
+{% endblock content %}
+
+{% block javascripts %}
+<script>
+function toggleThoughts(btn) {
+  const body = btn.nextElementSibling;
+  if (!body) return;
+  const hidden = body.style.display === 'none';
+  body.style.display = hidden ? 'block' : 'none';
+  btn.textContent = hidden ? 'Ocultar raciocínio' : 'Ver raciocínio';
+}
+</script>
+{% endblock javascripts %}

--- a/apps/templates/admin/conversations.html
+++ b/apps/templates/admin/conversations.html
@@ -1,0 +1,189 @@
+{% extends "layouts/base.html" %}
+{% block title %} Conversas Externas {% endblock title %}
+
+{% block stylesheets %}
+<style>
+  .conv-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+  }
+  .conv-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: box-shadow .15s, border-color .15s;
+    text-decoration: none;
+    color: inherit;
+  }
+  .conv-card:hover {
+    box-shadow: 0 4px 16px rgba(0,0,0,.08);
+    border-color: #6366f1;
+    text-decoration: none;
+    color: inherit;
+  }
+  .conv-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .conv-title {
+    font-weight: 600;
+    font-size: .95rem;
+    color: #1e293b;
+    line-height: 1.35;
+    flex: 1;
+    word-break: break-word;
+  }
+  .conv-badge {
+    background: #f1f5f9;
+    color: #64748b;
+    border-radius: 999px;
+    font-size: .72rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .conv-preview {
+    font-size: .83rem;
+    color: #64748b;
+    line-height: 1.45;
+    border-left: 3px solid #e2e8f0;
+    padding-left: 10px;
+  }
+  .conv-preview.sender-bot {
+    border-left-color: #6366f1;
+  }
+  .conv-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: .75rem;
+    color: #94a3b8;
+  }
+  .conv-empty {
+    text-align: center;
+    padding: 60px 20px;
+    color: #94a3b8;
+  }
+  .conv-empty i {
+    font-size: 2.5rem;
+    display: block;
+    margin-bottom: 12px;
+  }
+  .page-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .page-header-row h3 {
+    margin: 0;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #1e293b;
+  }
+  .page-meta {
+    font-size: .82rem;
+    color: #94a3b8;
+  }
+  .pagination-row {
+    display: flex;
+    justify-content: center;
+    margin-top: 32px;
+    gap: 8px;
+  }
+  .pagination-row a,
+  .pagination-row span {
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: .85rem;
+    border: 1px solid #e5e7eb;
+    text-decoration: none;
+    color: #374151;
+  }
+  .pagination-row a:hover { background: #f1f5f9; }
+  .pagination-row .current-page {
+    background: #6366f1;
+    color: #fff;
+    border-color: #6366f1;
+  }
+</style>
+{% endblock stylesheets %}
+
+{% block content %}
+<div class="container py-4">
+
+  <div class="page-header-row">
+    <div>
+      <h3><i class="ti-world" style="font-size:1.1rem; margin-right:6px; color:#6366f1;"></i>Conversas Externas</h3>
+      <span class="page-meta">{{ total_threads }} conversa{{ 's' if total_threads != 1 else '' }} de usuários externos (sem login)</span>
+    </div>
+  </div>
+
+  {% if conversations %}
+  <div class="conv-grid">
+    {% for c in conversations %}
+    <a class="conv-card" href="{{ url_for('authentication_blueprint.admin_conversation_detail', thread_id=c.thread_id) }}">
+      <div class="conv-card-header">
+        <span class="conv-title">{{ c.title }}</span>
+        <span class="conv-badge">{{ c.msg_count }} msg{{ 's' if c.msg_count != 1 else '' }}</span>
+      </div>
+      {% if c.last_preview %}
+      <div class="conv-preview {{ 'sender-bot' if c.last_sender == 'bot' else '' }}">
+        <strong style="font-size:.7rem;text-transform:uppercase;letter-spacing:.04em;opacity:.7;">
+          {{ 'Assistente' if c.last_sender == 'bot' else 'Usuário' }}
+        </strong><br>
+        {{ c.last_preview }}{% if c.last_preview|length >= 100 %}…{% endif %}
+      </div>
+      {% endif %}
+      <div class="conv-footer">
+        <span><i class="ti-tag" style="margin-right:4px;"></i>{{ c.thread_id[:12] }}…</span>
+        {% if c.last_at %}
+        <span>{{ c.last_at.strftime('%d/%m/%Y %H:%M') }}</span>
+        {% endif %}
+      </div>
+    </a>
+    {% endfor %}
+  </div>
+
+  {% if total_pages > 1 %}
+  <div class="pagination-row">
+    {% if page > 1 %}
+    <a href="{{ url_for('authentication_blueprint.admin_conversations', page=page-1) }}">&larr; Anterior</a>
+    {% endif %}
+
+    {% for p in range(1, total_pages+1) %}
+      {% if p == page %}
+        <span class="current-page">{{ p }}</span>
+      {% elif p <= 3 or p >= total_pages-2 or (p >= page-2 and p <= page+2) %}
+        <a href="{{ url_for('authentication_blueprint.admin_conversations', page=p) }}">{{ p }}</a>
+      {% elif p == 4 or p == total_pages-3 %}
+        <span style="border:none;padding:6px 4px;color:#94a3b8;">…</span>
+      {% endif %}
+    {% endfor %}
+
+    {% if page < total_pages %}
+    <a href="{{ url_for('authentication_blueprint.admin_conversations', page=page+1) }}">Próxima &rarr;</a>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {% else %}
+  <div class="conv-empty">
+    <i class="ti-comments"></i>
+    <p style="font-size:1rem;font-weight:600;color:#475569;margin-bottom:4px;">Nenhuma conversa externa ainda</p>
+    <p style="font-size:.85rem;">As conversas de usuários externos (sem login) aparecerão aqui.</p>
+  </div>
+  {% endif %}
+
+</div>
+{% endblock content %}

--- a/apps/templates/includes/sidebar.html
+++ b/apps/templates/includes/sidebar.html
@@ -99,6 +99,17 @@
           <span class="title">Feedbacks Negativos</span>
         </a>
       </li>
+
+      <li class="nav-item">
+        <a
+          class="sidebar-link {{ 'actived' if current_endpoint in ['authentication_blueprint.admin_conversations', 'authentication_blueprint.admin_conversation_detail'] else '' }}"
+          href="{{ url_for('authentication_blueprint.admin_conversations') }}"
+          title="Conversas Externas"
+        >
+          <span class="icon-holder"><i class="ti-world"></i></span>
+          <span class="title">Conversas Externas</span>
+        </a>
+      </li>
       {% endif %}
     </ul>
   </div>


### PR DESCRIPTION
Adiciona visibilidade completa para o admin sobre as conversas de usuários anônimos (ENV=prod, sem login). Inclui listagem paginada por thread e visualização detalhada em bolhas de chat, com raciocínio recolhível do bot. Link "Conversas Externas" adicionado ao sidebar.