### PR TITLE
fix: RAG não encontrava respostas em documentos estruturados (tabelas…

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -371,11 +371,13 @@ Consulta de Busca (responda SOMENTE com a query, sem explicações):""")
 
 def _render_answer(answer: str, sources: list[dict[str, Any]]) -> str:
     a = (answer or "").strip()
-    if not a:
-        a = NOT_FOUND_ANSWER
-
-    if not sources:
+    # Se o LLM não gerou resposta ou retornou explicitamente NOT_FOUND, não há o que renderizar
+    if not a or a == NOT_FOUND_ANSWER:
         return f"Resposta:\n{NOT_FOUND_ANSWER}"
+
+    # Resposta válida: apresenta o texto e, se houver fontes, lista-as
+    if not sources:
+        return f"Resposta:\n{a}"
 
     lines = [f"Resposta:\n{a}", "", "Fontes:"]
     for source in sources:
@@ -388,6 +390,26 @@ def _render_answer(answer: str, sources: list[dict[str, Any]]) -> str:
         else:
             lines.append(f"- {title}{page_part}")
     return "\n".join(lines).strip()
+
+
+def _extract_keywords(question: str) -> str:
+    """
+    Extrai os termos mais informativos da pergunta para formar uma query de busca ampla.
+    Remove stop words e palavras interrogativas, mantendo nomes, substantivos e termos técnicos.
+    Exemplo: "quais as disciplinas do professor sekeff?" → "disciplinas professor sekeff"
+    """
+    stop_words = {
+        "quais", "qual", "o", "a", "os", "as", "de", "do", "da", "dos", "das",
+        "em", "no", "na", "nos", "nas", "por", "para", "com", "que", "é", "são",
+        "me", "meu", "minha", "meus", "minhas", "um", "uma", "uns", "umas",
+        "isso", "este", "esta", "estes", "estas", "esse", "essa", "esses", "essas",
+        "tem", "ter", "há", "foi", "ser", "como", "quando", "onde", "se", "seu",
+        "sua", "seus", "suas", "quem", "quanto", "quantos", "quantas", "já",
+    }
+    import re
+    tokens = re.sub(r"[^\w\sÀ-ÿ]", " ", (question or "").lower()).split()
+    keywords = [t for t in tokens if t not in stop_words and len(t) > 2]
+    return " ".join(keywords)
 
 
 def consulta_institucional(
@@ -434,11 +456,22 @@ def consulta_institucional(
 
     answer = (answer or "").strip()
     if answer == NOT_FOUND_ANSWER:
-        # Retry: a query reescrita pode ter sido específica demais e perdeu o documento correto.
+        # Retry 1: a query reescrita pode ter sido específica demais e perdeu o documento correto.
         # Tentamos novamente com a pergunta original (sem reescrita de contexto).
+        retry_queries: list[str] = []
+
         if search_query.strip().lower() != question.strip().lower():
-            print(f"[RAG][RETRY] LLM retornou NOT_FOUND após query reescrita. Tentando com pergunta original.")
-            retrieval2 = retrieve_with_threshold(question, k=k, score_threshold=score_threshold)
+            retry_queries.append(question)
+
+        # Retry 2: extrai os substantivos/termos-chave da pergunta para ampliar a busca.
+        # Exemplo: "quais as disciplinas do professor sekeff?" → "professor sekeff disciplinas"
+        keywords = _extract_keywords(question)
+        if keywords and keywords.strip().lower() not in [q.strip().lower() for q in retry_queries + [search_query, question]]:
+            retry_queries.append(keywords)
+
+        for i, retry_q in enumerate(retry_queries, start=1):
+            print(f"[RAG][RETRY {i}] LLM retornou NOT_FOUND. Tentando com query alternativa: '{retry_q[:80]}'")
+            retrieval2 = retrieve_with_threshold(retry_q, k=k, score_threshold=score_threshold)
             if retrieval2.get("status") == "success":
                 docs2 = retrieval2.get("docs") or []
                 sources2 = retrieval2.get("sources") or []
@@ -455,7 +488,7 @@ def consulta_institucional(
                 )
                 answer2 = (answer2 or "").strip()
                 if answer2 and answer2 != NOT_FOUND_ANSWER:
-                    print(f"[RAG][RETRY] Retry bem-sucedido com query original.")
+                    print(f"[RAG][RETRY {i}] Retry bem-sucedido.")
                     return {
                         "status": "success",
                         "answer": answer2,
@@ -463,7 +496,7 @@ def consulta_institucional(
                         "docs": docs2,
                         "rendered": _render_answer(answer2, sources2),
                     }
-                print(f"[RAG][RETRY] Retry também retornou NOT_FOUND.")
+                print(f"[RAG][RETRY {i}] Retry também retornou NOT_FOUND.")
 
         rendered = f"Resposta:\n{NOT_FOUND_ANSWER}"
         return {

--- a/apps/core/chat/prompts/conversational_prompt.py
+++ b/apps/core/chat/prompts/conversational_prompt.py
@@ -13,8 +13,9 @@ Pergunta atual:
 
 INSTRUÇÕES CRÍTICAS:
 1. Você CONHECE a data de hoje: {today}. Use isso para raciocinar sobre "já passou", "falta quanto tempo", "há quantos dias" quando o histórico contiver a data de referência.
-2. Responda SOMENTE com informações que estejam EXPLICITAMENTE no histórico da conversa acima. NÃO invente datas, nomes, números ou fatos que não estejam no histórico. Se a informação não estiver no histórico, diga claramente: "Não tenho essa informação no nosso histórico de conversa."
-3. Mantenha o escopo do IFPI: responda apenas sobre assuntos relacionados à instituição (aulas, provas, horários, procedimentos, professores, cursos). Recuse educadamente perguntas completamente fora desse escopo.
-4. Tom natural, direto e humano. Use Markdown quando ajudar na leitura.
-5. NÃO cite fontes nesta resposta.
+2. Responda com informações que estejam no histórico da conversa. NÃO invente datas, nomes, números ou fatos.
+3. Se a pergunta for sobre algo que não está no histórico E que você não consegue responder apenas com a data de hoje, responda: "Não encontrei essa informação. Tente perguntar de forma mais direta ou consulte os documentos do IFPI." — Nunca diga "no nosso histórico de conversa" para perguntas factuais sobre professores, disciplinas, horários ou documentos, pois isso confunde o usuário.
+4. Mantenha o escopo do IFPI: responda apenas sobre assuntos relacionados à instituição (aulas, provas, horários, procedimentos, professores, cursos). Recuse educadamente perguntas completamente fora desse escopo.
+5. Tom natural, direto e humano. Use Markdown quando ajudar na leitura.
+6. NÃO cite fontes nesta resposta.
 """

--- a/apps/core/chat/prompts/rag_prompt.py
+++ b/apps/core/chat/prompts/rag_prompt.py
@@ -16,8 +16,8 @@ Pergunta:
 
 Instruções CRÍTICAS:
 1. Responda APENAS com base no Contexto acima.
-2. Se o Contexto não contiver a informação necessária de forma explícita, responda exatamente: {not_found_answer}
-3. É proibido inventar fatos, prazos, nomes, artigos, números, procedimentos ou interpretações que não estejam explícitos no Contexto.
+2. Se o Contexto contiver a informação — mesmo que apresentada em tabelas, grades de horário, listas ou formatos estruturados — EXTRAIA e apresente essa informação de forma clara. Só responda exatamente "{not_found_answer}" se o Contexto claramente não tiver NENHUMA informação relacionada à pergunta.
+3. É proibido inventar fatos, prazos, nomes, artigos, números, procedimentos ou interpretações que não estejam no Contexto. Mas raciocinar e organizar o que está no Contexto é permitido e esperado.
 4. Produza SOMENTE o texto da resposta (sem seção de fontes, sem listas de links e sem citar "Fonte 1", etc.).
 5. Use o histórico recente para manter continuidade e resolver referências ("isso", "aquilo", "antes").
 6. CÁLCULO DE DATAS: Você CONHECE a data de hoje ({today}). Se o Contexto contiver uma data de evento (ex: "prova em 5 de maio") e a pergunta pedir cálculo temporal ("há quantos dias", "falta quanto tempo", "já passou?"), FAÇA o cálculo usando a data de hoje. Isso não é invenção — é raciocínio sobre dados explícitos do Contexto.


### PR DESCRIPTION
…/grades)

Três correções em cascata para o problema de perguntas como 'quais as disciplinas do professor X?' retornarem resposta vazia:

1. rag_prompt: remove exigência de 'explícita' na instrução #2 — o LLM agora extrai informações de tabelas, grades e listas, não apenas de texto narrativo direto.

2. _render_answer: corrige bug onde resposta válida do LLM era descartada quando sources estivesse vazio; agora exibe a resposta sem lista de fontes.

3. RAG retry com keywords: adiciona _extract_keywords() que gera uma query mais ampla (ex: 'professor sekeff disciplinas') quando a query original falha, tentando até 2 alternativas antes de desistir.

4. conversational_prompt: remove 'no nosso histórico de conversa' da mensagem de fallback para perguntas factuais — não confunde o usuário sobre onde foi buscada a informação.