### PR TITLE
fix: responsividade mobile — campo de envio sempre visível em celulares

### DIFF
--- a/apps/static/assets/css/index-chat.css
+++ b/apps/static/assets/css/index-chat.css
@@ -604,9 +604,12 @@ body.app.chat-layout-page {
   font-size: 0.78rem;
 }
 
+/* ══════════════════════════════════════════════════════════════
+   TABLET (≤ 991px)
+   ══════════════════════════════════════════════════════════════ */
 @media (max-width: 991.98px) {
   .chat-page {
-    padding-bottom: 10px;
+    padding-bottom: 0;
   }
 
   .chat-container {
@@ -619,7 +622,7 @@ body.app.chat-layout-page {
   }
 
   .chat-footer {
-    padding: 14px 14px calc(14px + env(safe-area-inset-bottom));
+    padding: 14px 14px calc(14px + env(safe-area-inset-bottom, 0px));
   }
 
   .chat-input-shell {
@@ -633,6 +636,174 @@ body.app.chat-layout-page {
 
   .chat-bubble {
     max-width: 100%;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   MOBILE PHONES (≤ 767px)
+   Prioridade: campo de envio SEMPRE visível, teclado virtual OK
+   ══════════════════════════════════════════════════════════════ */
+@media (max-width: 767.98px) {
+
+  /* ── Viewport: usa --real-vh (atualizado via JS quando teclado abre) ── */
+  .chat-page {
+    /* Fallback em cascata: real-vh > dvh > svh > vh */
+    height: var(--real-vh, 100dvh);
+    padding-bottom: 0;
+    overflow: hidden;
+  }
+
+  /* ── Container principal: flex-column que não vaza ── */
+  .chat-container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 0;
+  }
+
+  .chat-main {
+    flex: 1;
+    min-height: 0;   /* CRÍTICO: sem isso o flex-child ignora overflow */
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* ── Área de mensagens: scroll vertical, sem clips ── */
+  .chat-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;  /* momentum scroll no iOS */
+    overscroll-behavior-y: contain;
+    /* Padding menor — o footer abaixo já cuida do espaço */
+    padding: 16px 14px 24px;
+  }
+
+  /* ── Footer: sempre visível, grudado no fundo, acima do teclado ── */
+  .chat-footer {
+    flex: 0 0 auto;           /* não encolhe nem cresce */
+    min-height: 60px;
+    /* safe-area-inset-bottom = espaço da "home bar" do iPhone */
+    padding: 10px 12px max(12px, env(safe-area-inset-bottom, 12px));
+    background: rgba(248, 250, 252, 0.98);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-top: 1px solid var(--border);
+    /* z-index garante que fique acima de qualquer scroll */
+    z-index: 20;
+  }
+
+  /* ── Campo de texto: font-size 16px previne zoom automático no iOS ── */
+  .chat-input {
+    font-size: 16px;   /* OBRIGATÓRIO: iOS faz zoom se < 16px */
+    min-height: 24px;
+  }
+
+  .chat-input-shell {
+    padding: 10px 10px 10px 14px;
+    border-radius: 16px;
+    gap: 8px;
+  }
+
+  /* ── Botão enviar: tamanho de toque confortável (≥ 44px recomendado) ── */
+  .chat-send {
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    touch-action: manipulation; /* sem delay de 300ms no tap */
+  }
+
+  /* Esconde dica de atalho (sem sentido em mobile) */
+  .chat-hint {
+    display: none;
+  }
+
+  /* ── Mensagens ── */
+  .chat-message {
+    width: 100%;
+    margin-bottom: 12px;
+    gap: 8px;
+    align-items: flex-end;
+  }
+
+  .chat-bubble {
+    max-width: 88%;
+    font-size: 0.93rem;
+    padding: 11px 14px;
+    border-radius: 16px;
+    line-height: 1.55;
+  }
+
+  /* Avatar menor */
+  .chat-avatar {
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+  }
+
+  /* ── Tela de boas-vindas ── */
+  .welcome-message {
+    padding: 24px 18px;
+  }
+
+  .welcome-message h1 {
+    font-size: clamp(1.3rem, 5.5vw, 1.75rem);
+    margin-bottom: 12px;
+  }
+
+  /* ── Chips de fonte: scroll horizontal em vez de quebrar linha ── */
+  .bot-sources-chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 2px;
+  }
+  .bot-sources-chips::-webkit-scrollbar { display: none; }
+
+  .bot-source-name {
+    max-width: 58vw;
+  }
+
+  /* ── Estado inicial: centraliza a caixa de input ── */
+  .chat-container.initial-state .chat-footer {
+    padding: 10px 12px max(16px, env(safe-area-inset-bottom, 16px));
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TELAS MUITO PEQUENAS (≤ 380px — iPhone SE 1ª geração, etc.)
+   ══════════════════════════════════════════════════════════════ */
+@media (max-width: 380px) {
+  .chat-footer {
+    padding: 8px 10px max(10px, env(safe-area-inset-bottom, 10px));
+    min-height: 56px;
+  }
+
+  .chat-input-shell {
+    padding: 8px 8px 8px 12px;
+    gap: 6px;
+  }
+
+  .chat-send {
+    width: 38px;
+    height: 38px;
+  }
+
+  /* Mantém 16px mesmo em tela pequena para não causar zoom no iOS */
+  .chat-input { font-size: 16px; }
+
+  .chat-bubble {
+    font-size: 0.88rem;
+    padding: 10px 12px;
+    max-width: 92%;
+  }
+
+  .welcome-message h1 {
+    font-size: clamp(1.15rem, 5vw, 1.4rem);
   }
 }
 

--- a/apps/templates/home/index.html
+++ b/apps/templates/home/index.html
@@ -9,6 +9,21 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link type="text/css" href="{{ config.ASSETS_ROOT }}/css/index-chat.css" rel="stylesheet">
+<!-- Viewport dinâmico: mantém --real-vh atualizado quando o teclado virtual abre/fecha -->
+<script>
+(function () {
+  function updateVh() {
+    var h = (window.visualViewport ? window.visualViewport.height : window.innerHeight);
+    document.documentElement.style.setProperty('--real-vh', h + 'px');
+  }
+  updateVh();
+  window.addEventListener('resize', updateVh);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', updateVh);
+    window.visualViewport.addEventListener('scroll', updateVh);
+  }
+})();
+</script>
 
 <div class="chat-page">
   <div id="chat-container" class="chat-container initial-state" role="application" aria-label="Chatbot IFPI">

--- a/apps/templates/layouts/base-prod.html
+++ b/apps/templates/layouts/base-prod.html
@@ -2,25 +2,67 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>IFPIA – {% block title %}Chatbot{% endblock %}</title>
   <link type="text/css" href="{{ config.ASSETS_ROOT }}/css/index.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
   {% block stylesheets %}{% endblock %}
   <style>
-    /* Layout limpo sem sidebar/navbar para usuários externos */
-    body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; background: #F8FAFC; }
-    .prod-shell { display: flex; flex-direction: column; height: 100vh; }
+    /* ── Layout prod: sem sidebar/navbar para usuários externos ── */
+    :root {
+      --prod-topbar-h: 52px;
+      /* Informa ao index-chat.css qual é a altura do topo */
+      --navbar-height: calc(var(--prod-topbar-h) + env(safe-area-inset-top, 0px));
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+
+    html {
+      height: 100%;
+      /* Fallback para Safari iOS que ainda não suporta 100dvh em versões antigas */
+      height: -webkit-fill-available;
+    }
+    body {
+      margin: 0; padding: 0;
+      height: 100%;
+      min-height: 100dvh;
+      min-height: -webkit-fill-available;
+      overflow: hidden;
+      background: #F8FAFC;
+    }
+
+    .prod-shell {
+      display: flex;
+      flex-direction: column;
+      /* 100dvh = viewport dinâmico (exclui teclado virtual no Android) */
+      height: 100dvh;
+      height: 100vh; /* fallback para browsers sem suporte a dvh */
+      min-height: -webkit-fill-available;
+    }
+
     .prod-topbar {
       display: flex; align-items: center; justify-content: space-between;
-      padding: 0 20px; height: 52px; background: #fff;
-      border-bottom: 1px solid rgba(15,23,42,.08); flex-shrink: 0;
+      padding: 0 20px;
+      /* Compensa notch/safe-area no topo (iPhone) */
+      padding-top: env(safe-area-inset-top, 0px);
+      height: var(--prod-topbar-h);
+      min-height: var(--prod-topbar-h);
+      background: #fff;
+      border-bottom: 1px solid rgba(15,23,42,.08);
+      flex-shrink: 0;
+      z-index: 10;
     }
     .prod-topbar-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
     .prod-topbar-brand img { height: 28px; }
     .prod-topbar-name { font-size: .9rem; font-weight: 700; color: #1f2937; }
     .prod-topbar-sub  { font-size: .72rem; color: #6b7280; }
-    .prod-content { flex: 1; overflow: hidden; }
+
+    /* prod-content ocupa EXATAMENTE o espaço restante abaixo do topbar */
+    .prod-content {
+      flex: 1;
+      min-height: 0;       /* essencial para que flex filhos respeitem overflow */
+      overflow: hidden;
+      position: relative;
+    }
   </style>
 </head>
 <body>

--- a/apps/templates/layouts/base.html
+++ b/apps/templates/layouts/base.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>
         IFPIA - {% block title %}{% endblock %}
     </title>


### PR DESCRIPTION
Três bugs combinados escondiam o footer em phones:

1. base-prod.html: prod-topbar (52px) não era descontado da altura do chat-page (usava --navbar-height: 0px = 100dvh), então o footer ficava 52px abaixo do viewport, cortado pelo overflow:hidden. Corrigido: --navbar-height: 52px + safe-area-inset-top no topo.

2. index-chat.css: novo breakpoint @media (max-width: 767px) com:
   - height: var(--real-vh, 100dvh) — usa viewport dinâmico atualizado por JS quando o teclado virtual abre/fecha
   - chat-footer: flex: 0 0 auto + min-height: 60px — nunca encolhe
   - chat-body: min-height: 0 + overflow-y: auto — scroll correto
   - font-size: 16px no input — previne zoom automático no iOS
   - env(safe-area-inset-bottom) no footer — respeita home bar do iPhone
   - touch-action: manipulation no botão — remove delay de 300ms
   - Breakpoint extra para telas ≤ 380px (iPhone SE 1ª geração)

3. index.html: script inline que ouve window.visualViewport e atualiza --real-vh — garante que a altura real (excluindo teclado) seja sempre a usada pelo layout, em iOS 14 e Android mais antigos.

4. Viewport meta: shrink-to-fit=no → viewport-fit=cover nos dois layouts (prod e dev) para habilitar env(safe-area-inset-*).