### PR TITLE
fix: remove viewport-fit=cover para corrigir sobreposição da barra de…

### DIFF
--- a/apps/templates/layouts/base-prod.html
+++ b/apps/templates/layouts/base-prod.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>IFPIA – {% block title %}Chatbot{% endblock %}</title>
   <link type="text/css" href="{{ config.ASSETS_ROOT }}/css/index.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
… navegação Android

Sem viewport-fit=cover, o browser reserva automaticamente o espaço da barra de sistema (Android nav bar / iOS home indicator), sem depender de env(safe-area-inset-bottom) que retornava 0 em dispositivos Samsung/Motorola com navegação de 3 botões.