### PR TITLE
fix: chat-page usa height:100% em prod — elimina corte do footer no m…

### DIFF
--- a/apps/static/assets/css/index-chat.css
+++ b/apps/static/assets/css/index-chat.css
@@ -29,6 +29,16 @@
   overflow: hidden;
  }
 
+ /*
+  * Modo prod: .prod-content já tem a altura exata resolvida via flexbox
+  * (prod-shell 100dvh − topbar 52px). Usar height:100% elimina qualquer
+  * discrepância entre visualViewport.height e 100dvh/100vh.
+  */
+ body.prod-layout .chat-page {
+  height: 100% !important;
+  padding-bottom: 0 !important;
+ }
+
 .sidebar-chat-item {
   margin-top: 4px;
 }

--- a/apps/templates/layouts/base-prod.html
+++ b/apps/templates/layouts/base-prod.html
@@ -65,7 +65,7 @@
     }
   </style>
 </head>
-<body>
+<body class="prod-layout">
   <div class="prod-shell">
     <header class="prod-topbar">
       <a class="prod-topbar-brand" href="{{ url_for('home_blueprint.index') }}">


### PR DESCRIPTION
…obile

Em prod mode, prod-content já tem a altura exata resolvida por flexbox (prod-shell 100dvh − topbar 52px). Qualquer diferença mínima entre visualViewport.height e 100dvh/100vh fazia o chat-page ser calculado com altura incorreta, causando overflow que o prod-content cortava.

Solução: body.prod-layout (novo class) + height:100% no chat-page herda diretamente o espaço já computado pelo flexbox, sem depender de cálculos de viewport. Em dev/admin mode o calc permanece inalterado.