### PR TITLE
fix: footer sticky + prod-content scrollável — input sempre acessível

### DIFF
--- a/apps/static/assets/css/index-chat.css
+++ b/apps/static/assets/css/index-chat.css
@@ -30,13 +30,28 @@
  }
 
  /*
-  * Modo prod: .prod-content já tem a altura exata resolvida via flexbox
-  * (prod-shell 100dvh − topbar 52px). Usar height:100% elimina qualquer
-  * discrepância entre visualViewport.height e 100dvh/100vh.
+  * Modo prod: prod-content agora faz o scroll. chat-page e chat-container
+  * usam min-height:100% para preencher o espaço disponível; se o conteúdo
+  * for maior, prod-content rola verticalmente e o footer sticky gruda no fundo.
   */
  body.prod-layout .chat-page {
-  height: 100% !important;
+  height: auto !important;
+  min-height: 100% !important;
   padding-bottom: 0 !important;
+  overflow: visible !important;
+ }
+
+ body.prod-layout .chat-container {
+  height: auto !important;
+  min-height: 100% !important;
+  overflow: visible !important;
+ }
+
+ /* Footer sticky: permanece colado na borda inferior de prod-content
+    independente de qualquer discrepância de cálculo de altura */
+ body.prod-layout .chat-footer {
+  position: sticky !important;
+  bottom: 0 !important;
  }
 
 .sidebar-chat-item {

--- a/apps/templates/layouts/base-prod.html
+++ b/apps/templates/layouts/base-prod.html
@@ -56,11 +56,12 @@
     .prod-topbar-name { font-size: .9rem; font-weight: 700; color: #1f2937; }
     .prod-topbar-sub  { font-size: .72rem; color: #6b7280; }
 
-    /* prod-content ocupa EXATAMENTE o espaço restante abaixo do topbar */
+    /* prod-content ocupa o espaço restante abaixo do topbar e rola se necessário */
     .prod-content {
       flex: 1;
-      min-height: 0;       /* essencial para que flex filhos respeitem overflow */
-      overflow: hidden;
+      min-height: 0;
+      overflow-y: auto;   /* scroll vertical quando o conteúdo for maior que o espaço */
+      -webkit-overflow-scrolling: touch;
       position: relative;
     }
   </style>


### PR DESCRIPTION
Substituição da estratégia de height fixo por scroll natural:
- prod-content: overflow-y:auto (rola quando conteúdo transbordar)
- chat-page/chat-container: height:auto + min-height:100% (sem cálculo de viewport)
- chat-footer: position:sticky bottom:0 (gruda no fundo do prod-content independente de qualquer discrepância entre 100dvh e visualViewport.height)

O footer agora é visível em qualquer tamanho de tela e configuração de barra do sistema Android/iOS, sem depender de cálculos de altura exatos.