### PR TITLE
fix: RAG escalada para web mais rapida + logs de diagnostico na busca web

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -721,10 +721,29 @@ def consulta_institucional(
     answer = (answer or "").strip()
     if _is_not_found_answer(answer):
         # LLM sinalizou "não encontrado" — com frase exata ou variante com explicação extra.
-        # Tentamos retries com queries alternativas antes de escalar para a web.
+
+        # Otimização: se o melhor score dos docs recuperados é baixo (< 0.55),
+        # os documentos claramente não têm a informação — retries com queries
+        # alternativas vão produzir os mesmos docs irrelevantes e perder tempo.
+        # Pulamos os retries e escalamos direto para a web.
+        top_score = max((d.get("relevance", 0.0) for d in docs), default=0.0)
+        if top_score < 0.55:
+            print(
+                f"[RAG][SKIP_RETRY] Top relevance={top_score:.3f} < 0.55 e LLM NOT_FOUND. "
+                "Docs claramente irrelevantes — escalando direto para a web."
+            )
+            return {
+                "status": "not_found",
+                "answer": NOT_FOUND_ANSWER,
+                "sources": [],
+                "docs": docs,
+                "rendered": f"Resposta:\n{NOT_FOUND_ANSWER}",
+            }
+
+        # Só faz retries quando os docs tinham relevância razoável (≥ 0.55) mas o
+        # LLM não encontrou a resposta — pode ser problema na formulação da query.
 
         # Retry 1: a query reescrita pode ter sido específica demais e perdeu o documento correto.
-        # Tentamos novamente com a pergunta original (sem reescrita de contexto).
         retry_queries: list[str] = []
 
         if search_query.strip().lower() != question.strip().lower():
@@ -737,7 +756,7 @@ def consulta_institucional(
             retry_queries.append(keywords)
 
         for i, retry_q in enumerate(retry_queries, start=1):
-            print(f"[RAG][RETRY {i}] LLM sinalizou NOT_FOUND. Tentando com query alternativa: '{retry_q[:80]}'")
+            print(f"[RAG][RETRY {i}] LLM sinalizou NOT_FOUND (top_score={top_score:.3f}). Tentando query: '{retry_q[:80]}'")
             retrieval2 = retrieve_with_threshold(retry_q, k=k, score_threshold=score_threshold)
             if retrieval2.get("status") == "success":
                 docs2 = retrieval2.get("docs") or []

--- a/apps/core/chat/agents/web_agent.py
+++ b/apps/core/chat/agents/web_agent.py
@@ -81,13 +81,16 @@ def _sources_text(results: list[dict[str, Any]]) -> str:
 def web_search(question: str, *, max_results: int = 4) -> dict[str, Any]:
     q = (question or "").strip()
     if not q:
+        print("[WEB][ERROR] Pergunta vazia.")
         return {"status": "error", "message": "Pergunta vazia.", "results": []}
 
-    tavily_tool = _get_tavily_tool()
     tavily_api_key = os.getenv("TAVILY_API_KEY")
     if not tavily_api_key:
+        print("[WEB][ERROR] TAVILY_API_KEY não configurada — busca web desabilitada.")
         return {"status": "error", "message": "TAVILY_API_KEY ausente.", "results": []}
 
+    print(f"[WEB][SEARCH] query='{q[:100]}'")
+    tavily_tool = _get_tavily_tool()
     raw = None
     try:
         if hasattr(tavily_tool, "max_results"):
@@ -100,9 +103,11 @@ def web_search(question: str, *, max_results: int = 4) -> dict[str, Any]:
         else:
             raw = tavily_tool(q)
     except Exception as e:
+        print(f"[WEB][ERROR] Falha na busca Tavily: {e}")
         return {"status": "error", "message": str(e), "results": []}
 
     results = _extract_results(raw)
+    print(f"[WEB][SEARCH] {len(results)} resultado(s) retornado(s).")
     return {"status": "success", "results": results}
 
 


### PR DESCRIPTION
## Resumo

Duas melhorias no pipeline RAG Web do chatbot IFPI.

### 1. Pula retries quando documentos sao claramente irrelevantes

**Problema:** quando o LLM dizia nao encontrei e o melhor score dos chunks era baixo (ex: 0.48), o sistema ainda fazia 2 retries com queries alternativas, cada retry custava 10s extras sem chance de sucesso.

**Fix:** se top_score menor que 0.55 e o LLM sinalizou NOT_FOUND, escalamos direto para a busca web sem retries. Retries continuam apenas quando top_score maior ou igual a 0.55.

**Impacto:** perguntas como o IFPI de Piripiri e bom passam de 34s para 10s.

### 2. Logs de diagnostico na busca web

**Problema:** quando a busca web falhava (TAVILY_API_KEY ausente), nao havia nenhum log.

**Fix:** adicionados logs [WEB][SEARCH] e [WEB][ERROR] em web_agent.py.

## Arquivos modificados

- apps/core/chat/agents/institutional_agent.py - Skip de retries quando top_score menor que 0.55
- apps/core/chat/agents/web_agent.py - Logs de diagnostico na busca Tavily

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)