### PR TITLE
fix: busca web — query keyword-based + filtro de escopo IFPI

### DIFF
--- a/apps/core/chat/agents/web_agent.py
+++ b/apps/core/chat/agents/web_agent.py
@@ -25,6 +25,52 @@ def _get_tavily_tool():
 NOT_FOUND_WEB = "Não foi possível obter fontes confiáveis na web."
 NOT_FOUND_ANSWER = "Não encontrei essa informação nos documentos oficiais do IFPI."
 
+_STOP_WORDS = {
+    "o", "a", "os", "as", "um", "uma", "uns", "umas", "de", "do", "da", "dos", "das",
+    "em", "no", "na", "nos", "nas", "por", "para", "com", "sem", "sob", "sobre",
+    "que", "e", "ou", "mas", "se", "como", "qual", "quais", "quando", "onde", "quem",
+    "é", "são", "foi", "eram", "está", "estão", "tem", "têm", "há", "ser", "ter",
+    "ao", "à", "pelo", "pela", "pelos", "pelas", "isso", "isto", "aquilo", "me", "te",
+    "lhe", "nos", "se", "já", "não", "sim", "muito", "mais", "menos", "bem", "mal",
+    "também", "ainda", "só", "até", "desde", "entre", "depois", "antes",
+    "qual", "quais", "quanto", "quantos", "quanta", "quantas",
+}
+
+_QUESTION_STARTERS = re.compile(
+    r"^(?:o que\s+|quem\s+|como\s+(?:é|está|são|estão|fica|ficam|funciona)?\s*|"
+    r"quando\s+|onde\s+|qual\s+(?:é|são)?\s*|quais\s+(?:são)?\s*|"
+    r"me\s+(?:fala|diga|explica|conta)\s+(?:sobre\s+)?"
+    r"|você\s+(?:sabe|pode|conhece)\s+(?:me\s+dizer\s+)?"
+    r"|(?:poderia?\s+)?(?:me\s+)?(?:dizer|informar|falar)\s+(?:sobre\s+|se\s+)?)",
+    re.IGNORECASE,
+)
+
+
+def _build_search_query(question: str) -> str:
+    """Convert a natural language question into a keyword-based search query."""
+    q = (question or "").strip()
+    if not q:
+        return q
+
+    # Strip leading question phrases ("como é", "me fala sobre", etc.)
+    q_clean = _QUESTION_STARTERS.sub("", q).strip()
+
+    # Tokenize and drop stop words
+    tokens = re.findall(r"[A-Za-zÀ-ÿ0-9]+", q_clean)
+    keywords = [t for t in tokens if t.lower() not in _STOP_WORDS and len(t) >= 3]
+
+    if not keywords:
+        keywords = [t for t in re.findall(r"[A-Za-zÀ-ÿ0-9]+", q) if len(t) >= 3]
+
+    # Ensure IFPI is part of the query for institutional scope
+    has_ifpi = any(t.upper() == "IFPI" for t in keywords)
+    if not has_ifpi:
+        keywords = ["IFPI"] + keywords
+
+    query = " ".join(keywords)
+    print(f"[WEB][QUERY] original='{question[:80]}' → query='{query[:100]}'")
+    return query
+
 _llm = None
 
 
@@ -89,7 +135,7 @@ def web_search(question: str, *, max_results: int = 4) -> dict[str, Any]:
         print("[WEB][ERROR] TAVILY_API_KEY não configurada — busca web desabilitada.")
         return {"status": "error", "message": "TAVILY_API_KEY ausente.", "results": []}
 
-    print(f"[WEB][SEARCH] query='{q[:100]}'")
+    query = _build_search_query(q)
     tavily_tool = _get_tavily_tool()
     raw = None
     try:
@@ -99,9 +145,9 @@ def web_search(question: str, *, max_results: int = 4) -> dict[str, Any]:
             except Exception:
                 pass
         if hasattr(tavily_tool, "invoke"):
-            raw = tavily_tool.invoke(q)
+            raw = tavily_tool.invoke(query)
         else:
-            raw = tavily_tool(q)
+            raw = tavily_tool(query)
     except Exception as e:
         print(f"[WEB][ERROR] Falha na busca Tavily: {e}")
         return {"status": "error", "message": str(e), "results": []}
@@ -118,7 +164,6 @@ def responder_web(
     conversation_context: str = "",
     user_profile: str = "",
 ) -> dict[str, Any]:
-    tavily_tool = _get_tavily_tool()
     search = web_search(question, max_results=max_results)
     results = search.get("results") or []
 

--- a/apps/core/chat/prompts/web_prompt.py
+++ b/apps/core/chat/prompts/web_prompt.py
@@ -15,12 +15,16 @@ Pergunta:
 {question}
 
 Instruções CRÍTICAS:
-1. Responda APENAS com base nos resultados acima.
-2. Se os resultados não forem suficientes para responder com segurança, responda exatamente: {not_found_answer}
-3. Não invente detalhes. Não extrapole além do que está nos trechos fornecidos.
-4. Use o histórico recente apenas para manter continuidade, resolver referências como "isso", "aquilo", "antes", "o documento anterior", sem inventar fatos novos.
-5. Se houver informação conhecida sobre o usuário, use isso apenas para personalizar tom e contexto; nunca invente dados pessoais.
-6. Produza SOMENTE o texto da resposta (sem seção de fontes, sem listas de links).
-7. Use Markdown com parágrafos curtos, tom natural e linguagem humana.
+1. VERIFICAÇÃO DE ESCOPO — leia ANTES de qualquer outra instrução:
+   • Você é um assistente do IFPI (Instituto Federal do Piauí). Responda SOMENTE perguntas relacionadas ao IFPI ou ao contexto educacional/institucional.
+   • Se a pergunta for sobre temas completamente alheios ao IFPI — previsão do tempo, esportes, notícias gerais, entretenimento, política, saúde geral, etc. — responda EXATAMENTE: {not_found_answer}
+   • Se os resultados da busca tratarem de locais, pessoas ou organizações sem relação com o IFPI (ex: outra cidade, outra instituição), não use esses resultados — responda EXATAMENTE: {not_found_answer}
+2. Responda APENAS com base nos resultados acima.
+3. Se os resultados não forem suficientes para responder com segurança sobre o IFPI, responda exatamente: {not_found_answer}
+4. Não invente detalhes. Não extrapole além do que está nos trechos fornecidos.
+5. Use o histórico recente apenas para manter continuidade, resolver referências como "isso", "aquilo", "antes", "o documento anterior", sem inventar fatos novos.
+6. Se houver informação conhecida sobre o usuário, use isso apenas para personalizar tom e contexto; nunca invente dados pessoais.
+7. Produza SOMENTE o texto da resposta (sem seção de fontes, sem listas de links).
+8. Use Markdown com parágrafos curtos, tom natural e linguagem humana.
 """
     return web_prompt


### PR DESCRIPTION
- _build_search_query(): converte pergunta em linguagem natural para query de palavras-chave (remove stop words, starters como "como é", "me fala sobre") e prefixa com IFPI quando ausente. Ex: "o IFPI de Piripiri é bom?" → "IFPI Piripiri bom"
- web_prompt.py: instrução 1 exige verificação de escopo antes de responder — rejeita resultados sem relação com o IFPI (previsão do tempo, esportes, etc.) com NOT_FOUND_ANSWER exato.
- Remove chamada redundante a _get_tavily_tool() em responder_web().