### PR TITLE
feat: memória temporária em prod + apagar/PDF conversas + visualizado…

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -7,6 +7,10 @@ import os
 import time
 
 from flask import Flask
+
+# Instala interceptor de logs antes de qualquer print do sistema
+from apps.core.log_buffer import install as _install_log_buffer
+_install_log_buffer()
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
 from importlib import import_module

--- a/apps/authentication/routes/admin_routes.py
+++ b/apps/authentication/routes/admin_routes.py
@@ -22,6 +22,7 @@ from apps.authentication import (
     DocumentoOficial,
     DocumentoVersao,
     LogProcessamento,
+    UserMemory,
 )
 from apps.core.documents.services.revision_orchestrator import executar_revisao_documento
 from apps.core.chat.services.serialization_service import build_conversation_summaries
@@ -390,4 +391,82 @@ def admin_conversation_detail(thread_id):
         messages=messages,
         thread_id=thread_id,
         title=title,
+    )
+
+
+@blueprint.route("/admin/conversations/<thread_id>/delete", methods=["POST"])
+@login_required
+@admin_required
+def admin_conversation_delete(thread_id):
+    """Apaga todos os registros de uma conversa externa."""
+    UserMemory.query.filter_by(thread_id=thread_id).delete()
+    ChatFeedback.query.filter_by(thread_id=thread_id).delete()
+    ChatMessage.query.filter(
+        ChatMessage.thread_id == thread_id,
+        ChatMessage.user_id.is_(None),
+    ).delete()
+    db.session.commit()
+    flash("Conversa apagada com sucesso.", "success")
+    return redirect(url_for("authentication_blueprint.admin_conversations"))
+
+
+@blueprint.route("/admin/conversations/<thread_id>/print")
+@login_required
+@admin_required
+def admin_conversation_print(thread_id):
+    """Versão para impressão/PDF de uma conversa."""
+    messages = (
+        ChatMessage.query
+        .filter(ChatMessage.thread_id == thread_id, ChatMessage.user_id.is_(None))
+        .order_by(ChatMessage.created_at.asc(), ChatMessage.id.asc())
+        .all()
+    )
+    if not messages:
+        flash("Conversa não encontrada.", "warning")
+        return redirect(url_for("authentication_blueprint.admin_conversations"))
+
+    first_user_msg = next((m for m in messages if m.sender == "user"), None)
+    title = (first_user_msg.content or "").strip()[:70] if first_user_msg else thread_id
+
+    return render_template(
+        "admin/conversation_print.html",
+        messages=messages,
+        thread_id=thread_id,
+        title=title,
+    )
+
+
+@blueprint.route("/admin/system-logs")
+@login_required
+@admin_required
+def admin_system_logs():
+    """Visualizador de logs do sistema em tempo real."""
+    from apps.core.log_buffer import get_lines
+    lines = get_lines(500)
+    return render_template("admin/system_logs.html", lines=lines)
+
+
+@blueprint.route("/admin/system-logs/data")
+@login_required
+@admin_required
+def admin_system_logs_data():
+    """Endpoint JSON com as últimas linhas de log (para auto-refresh via fetch)."""
+    from flask import jsonify
+    from apps.core.log_buffer import get_lines
+    n = min(int(request.args.get("n", 500)), 2000)
+    return jsonify({"lines": get_lines(n)})
+
+
+@blueprint.route("/admin/system-logs/export")
+@login_required
+@admin_required
+def admin_system_logs_export():
+    """Exporta os logs como arquivo .txt."""
+    from flask import Response
+    from apps.core.log_buffer import get_lines
+    content = "\n".join(get_lines(2000))
+    return Response(
+        content,
+        mimetype="text/plain; charset=utf-8",
+        headers={"Content-Disposition": "attachment; filename=sistema_logs.txt"},
     )

--- a/apps/core/log_buffer.py
+++ b/apps/core/log_buffer.py
@@ -1,0 +1,56 @@
+"""
+Buffer de logs em memória: intercepta sys.stdout para capturar todos os
+prints do sistema e disponibilizá-los via rota admin sem acesso ao Docker CLI.
+"""
+
+import sys
+import threading
+from collections import deque
+from datetime import datetime
+
+_MAX_LINES = 2000
+_buffer: deque[str] = deque(maxlen=_MAX_LINES)
+_lock = threading.Lock()
+_installed = False
+
+
+class _LogInterceptor:
+    def __init__(self, original):
+        self._original = original
+
+    def write(self, text: str):
+        self._original.write(text)
+        text = text.rstrip("\n")
+        if text:
+            ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            line = f"[{ts}] {text}"
+            with _lock:
+                _buffer.append(line)
+
+    def flush(self):
+        self._original.flush()
+
+    def fileno(self):
+        return self._original.fileno()
+
+    def isatty(self):
+        return False
+
+
+def install():
+    global _installed
+    if _installed:
+        return
+    sys.stdout = _LogInterceptor(sys.stdout)
+    _installed = True
+
+
+def get_lines(n: int = _MAX_LINES) -> list[str]:
+    with _lock:
+        lines = list(_buffer)
+    return lines[-n:] if n < len(lines) else lines
+
+
+def clear():
+    with _lock:
+        _buffer.clear()

--- a/apps/home/routes.py
+++ b/apps/home/routes.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 from apps.home import blueprint
-from flask import current_app, redirect, render_template, request, url_for
+from flask import current_app, redirect, render_template, request, session, url_for
 from flask_login import current_user
 from jinja2 import TemplateNotFound
 
@@ -11,6 +11,15 @@ def index():
     # Em dev, exige autenticação.
     if current_app.config.get('APP_ENV') != 'prod' and not current_user.is_authenticated:
         return redirect(url_for('authentication_blueprint.login'))
+
+    # Em prod, cada carregamento de página inicia uma sessão limpa:
+    # o thread_id anterior é descartado, apagando memória e histórico.
+    # Enquanto a página estiver aberta (sem reload) o histórico é mantido.
+    if current_app.config.get('APP_ENV') == 'prod':
+        session.pop('thread_id', None)
+        session.pop('chat_thread_ids', None)
+        session.modified = True
+
     return render_template('home/index.html', segment='index')
 
 

--- a/apps/templates/admin/conversation_detail.html
+++ b/apps/templates/admin/conversation_detail.html
@@ -151,6 +151,21 @@
         {{ messages|length }} mensagen{{ 's' if messages|length != 1 else '' }}
       </span>
     </div>
+    <div style="display:flex;gap:8px;flex-shrink:0;align-items:flex-start;">
+      <a href="{{ url_for('authentication_blueprint.admin_conversation_print', thread_id=thread_id) }}"
+         target="_blank"
+         style="display:inline-flex;align-items:center;gap:6px;font-size:.83rem;padding:5px 12px;border-radius:6px;border:1px solid #d1fae5;background:#ecfdf5;color:#065f46;text-decoration:none;white-space:nowrap;">
+        <i class="ti-export"></i> Exportar PDF
+      </a>
+      <form method="POST"
+            action="{{ url_for('authentication_blueprint.admin_conversation_delete', thread_id=thread_id) }}"
+            onsubmit="return confirm('Apagar esta conversa permanentemente?')">
+        <button type="submit"
+                style="display:inline-flex;align-items:center;gap:6px;font-size:.83rem;padding:5px 12px;border-radius:6px;border:1px solid #fee2e2;background:#fff1f2;color:#9f1239;cursor:pointer;white-space:nowrap;">
+          <i class="ti-trash"></i> Apagar
+        </button>
+      </form>
+    </div>
   </div>
 
   <div class="cd-messages">

--- a/apps/templates/admin/conversation_print.html
+++ b/apps/templates/admin/conversation_print.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Conversa — {{ title }}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Segoe UI', Arial, sans-serif;
+      font-size: 13px;
+      color: #1e293b;
+      background: #fff;
+      padding: 32px 40px;
+    }
+
+    /* Barra de ações — oculta ao imprimir */
+    .print-actions {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 28px;
+    }
+    .btn-print, .btn-back {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 16px;
+      border-radius: 6px;
+      font-size: 13px;
+      cursor: pointer;
+      border: 1px solid transparent;
+      text-decoration: none;
+    }
+    .btn-print {
+      background: #4f46e5;
+      color: #fff;
+    }
+    .btn-back {
+      background: #f1f5f9;
+      color: #374151;
+      border-color: #e2e8f0;
+    }
+
+    /* Cabeçalho */
+    .print-header {
+      border-bottom: 2px solid #e2e8f0;
+      padding-bottom: 16px;
+      margin-bottom: 24px;
+    }
+    .print-header h1 {
+      font-size: 17px;
+      font-weight: 700;
+      color: #1e293b;
+      margin-bottom: 4px;
+    }
+    .print-meta {
+      font-size: 11px;
+      color: #64748b;
+    }
+
+    /* Mensagens */
+    .messages { display: flex; flex-direction: column; gap: 14px; }
+
+    .msg { display: flex; gap: 10px; align-items: flex-start; }
+    .msg.user { flex-direction: row-reverse; }
+
+    .avatar {
+      width: 30px;
+      height: 30px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+    .avatar-user { background: #dbeafe; color: #1d4ed8; }
+    .avatar-bot  { background: #ede9fe; color: #6d28d9; }
+
+    .msg-wrap { display: flex; flex-direction: column; max-width: 72%; }
+    .msg.user .msg-wrap { align-items: flex-end; }
+
+    .bubble {
+      padding: 9px 13px;
+      border-radius: 12px;
+      font-size: 12.5px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .msg.user .bubble {
+      background: #2563eb;
+      color: #fff;
+      border-bottom-right-radius: 3px;
+    }
+    .msg.bot .bubble {
+      background: #f1f5f9;
+      color: #1e293b;
+      border: 1px solid #e2e8f0;
+      border-bottom-left-radius: 3px;
+    }
+
+    .ts {
+      font-size: 10px;
+      color: #94a3b8;
+      margin-top: 3px;
+    }
+
+    .date-sep {
+      text-align: center;
+      font-size: 10px;
+      color: #94a3b8;
+      margin: 6px 0;
+    }
+
+    .sender-label {
+      font-size: 10px;
+      font-weight: 600;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+      margin-bottom: 2px;
+    }
+
+    /* Print */
+    @media print {
+      .print-actions { display: none !important; }
+      body { padding: 16px 20px; }
+      .bubble { border: 1px solid #e2e8f0 !important; }
+    }
+  </style>
+</head>
+<body>
+
+  <div class="print-actions">
+    <button class="btn-print" onclick="window.print()">&#x1F5A8; Imprimir / Salvar PDF</button>
+    <a class="btn-back" href="javascript:history.back()">&#8592; Voltar</a>
+  </div>
+
+  <div class="print-header">
+    <h1>{{ title }}</h1>
+    <div class="print-meta">
+      Thread: {{ thread_id }} &nbsp;·&nbsp;
+      {{ messages|length }} mensagem{{ 's' if messages|length != 1 else '' }}
+      {% if messages and messages[0].created_at %}
+        &nbsp;·&nbsp; Início: {{ messages[0].created_at.strftime('%d/%m/%Y %H:%M') }}
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="messages">
+    {% for msg in messages %}
+
+    {% if loop.first or (messages[loop.index0 - 1].created_at and msg.created_at and
+        (msg.created_at - messages[loop.index0 - 1].created_at).total_seconds() > 3600) %}
+    <div class="date-sep">— {{ msg.created_at.strftime('%d/%m/%Y') if msg.created_at else '' }} —</div>
+    {% endif %}
+
+    <div class="msg {{ msg.sender }}">
+      <div class="avatar avatar-{{ msg.sender }}">
+        {{ 'U' if msg.sender == 'user' else 'B' }}
+      </div>
+      <div class="msg-wrap">
+        <div class="sender-label">{{ 'Usuário' if msg.sender == 'user' else 'Piazinho' }}</div>
+        <div class="bubble">{{ msg.content }}</div>
+        {% if msg.created_at %}
+        <div class="ts">{{ msg.created_at.strftime('%H:%M') }}</div>
+        {% endif %}
+      </div>
+    </div>
+
+    {% endfor %}
+  </div>
+
+</body>
+</html>

--- a/apps/templates/admin/system_logs.html
+++ b/apps/templates/admin/system_logs.html
@@ -1,0 +1,181 @@
+{% extends "layouts/base.html" %}
+{% block title %} Logs do Sistema {% endblock title %}
+
+{% block stylesheets %}
+<style>
+  .logs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .logs-header h3 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #1e293b;
+  }
+  .logs-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+
+  .btn-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: .82rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid transparent;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .btn-export { background: #ecfdf5; color: #065f46; border-color: #d1fae5; }
+  .btn-export:hover { background: #d1fae5; color: #065f46; text-decoration: none; }
+  .btn-clear  { background: #fff1f2; color: #9f1239; border-color: #fee2e2; }
+  .btn-clear:hover  { background: #fee2e2; }
+  .btn-refresh { background: #eff6ff; color: #1e40af; border-color: #bfdbfe; }
+  .btn-refresh:hover { background: #dbeafe; }
+
+  .log-status {
+    font-size: .78rem;
+    color: #94a3b8;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .log-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: #22c55e;
+    display: inline-block;
+    animation: blink 1.5s infinite;
+  }
+  @keyframes blink { 0%,100%{opacity:1} 50%{opacity:.3} }
+
+  .log-box {
+    background: #0f172a;
+    color: #94a3b8;
+    border-radius: 10px;
+    padding: 16px 18px;
+    font-family: 'Consolas', 'Courier New', monospace;
+    font-size: .78rem;
+    line-height: 1.7;
+    height: calc(100vh - 260px);
+    min-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .log-line { display: block; border-bottom: 1px solid rgba(255,255,255,.03); padding: 1px 0; }
+  .log-line:hover { background: rgba(255,255,255,.04); }
+
+  /* Colore por nível */
+  .log-line.lvl-error  { color: #f87171; }
+  .log-line.lvl-warn   { color: #fbbf24; }
+  .log-line.lvl-success{ color: #4ade80; }
+  .log-line.lvl-info   { color: #7dd3fc; }
+  .log-line.lvl-rag    { color: #c4b5fd; }
+  .log-line.lvl-web    { color: #67e8f9; }
+
+  .log-count {
+    font-size: .75rem;
+    color: #64748b;
+    margin-top: 8px;
+    text-align: right;
+  }
+</style>
+{% endblock stylesheets %}
+
+{% block content %}
+<div class="container-fluid py-4">
+
+  <div class="logs-header">
+    <div>
+      <h3><i class="ti-server" style="font-size:1rem;margin-right:6px;color:#6366f1;"></i>Logs do Sistema</h3>
+      <div class="log-status">
+        <span class="log-dot"></span>
+        Atualizando automaticamente a cada 5 segundos
+      </div>
+    </div>
+    <div class="logs-actions">
+      <button class="btn-action btn-refresh" onclick="fetchLogs()">
+        <i class="ti-reload"></i> Atualizar agora
+      </button>
+      <a class="btn-action btn-export"
+         href="{{ url_for('authentication_blueprint.admin_system_logs_export') }}">
+        <i class="ti-export"></i> Exportar .txt
+      </a>
+      <button class="btn-action btn-clear" onclick="clearDisplay()">
+        <i class="ti-trash"></i> Limpar tela
+      </button>
+    </div>
+  </div>
+
+  <div class="log-box" id="logBox">
+    {% for line in lines %}
+    <span class="log-line">{{ line }}</span>
+    {% endfor %}
+  </div>
+  <div class="log-count" id="logCount">{{ lines|length }} linha(s) carregadas</div>
+
+</div>
+{% endblock content %}
+
+{% block javascripts %}
+<script>
+(function () {
+  var box = document.getElementById('logBox');
+  var count = document.getElementById('logCount');
+  var autoScroll = true;
+  var intervalId = null;
+
+  function lineClass(text) {
+    var t = text.toLowerCase();
+    if (t.includes('[error]') || t.includes('erro') || t.includes('exception') || t.includes('traceback')) return 'lvl-error';
+    if (t.includes('[warn') || t.includes('warning'))  return 'lvl-warn';
+    if (t.includes('[rag]'))  return 'lvl-rag';
+    if (t.includes('[web]'))  return 'lvl-web';
+    if (t.includes('sucesso') || t.includes('success') || t.includes('concluíd')) return 'lvl-success';
+    if (t.includes('[info]') || t.includes('carregad') || t.includes('conectad')) return 'lvl-info';
+    return '';
+  }
+
+  function renderLines(lines) {
+    box.innerHTML = '';
+    lines.forEach(function (line) {
+      var span = document.createElement('span');
+      span.className = 'log-line ' + lineClass(line);
+      span.textContent = line;
+      box.appendChild(span);
+    });
+    count.textContent = lines.length + ' linha(s) carregadas';
+    if (autoScroll) box.scrollTop = box.scrollHeight;
+  }
+
+  window.fetchLogs = function () {
+    fetch("{{ url_for('authentication_blueprint.admin_system_logs_data') }}?n=500")
+      .then(function (r) { return r.json(); })
+      .then(function (data) { renderLines(data.lines || []); })
+      .catch(function () {});
+  };
+
+  window.clearDisplay = function () {
+    box.innerHTML = '';
+    count.textContent = '0 linha(s) — tela limpa (não apaga os logs do servidor)';
+  };
+
+  // Pausa auto-scroll quando usuário rola para cima
+  box.addEventListener('scroll', function () {
+    autoScroll = box.scrollTop + box.clientHeight >= box.scrollHeight - 40;
+  });
+
+  // Busca imediatamente para colorizar + auto-refresh a cada 5 segundos
+  fetchLogs();
+  intervalId = setInterval(fetchLogs, 5000);
+})();
+</script>
+{% endblock javascripts %}


### PR DESCRIPTION
…r de logs

Memória temporária (prod):
- home/routes.py: no carregamento da página em prod, limpa thread_id e chat_thread_ids da sessão Flask. Cada page load começa com histórico limpo; enquanto a aba estiver aberta o histórico é mantido.

Apagar / Exportar PDF conversas (admin):
- admin_routes.py: rotas POST /admin/conversations/<id>/delete (apaga ChatMessage, UserMemory e ChatFeedback do thread) e GET /admin/conversations/<id>/print (versão impressão).
- conversation_detail.html: botões "Exportar PDF" e "Apagar" no cabeçalho.
- conversation_print.html: template minimal estilo chat com CSS @media print; botão "Imprimir / Salvar PDF" aciona window.print().

Visualizador de logs do sistema (admin):
- core/log_buffer.py: intercepta sys.stdout com _LogInterceptor, mantém deque(maxlen=2000) thread-safe com timestamp em cada linha.
- apps/__init__.py: instala o interceptor antes de qualquer print.
- admin_routes.py: rotas /admin/system-logs (página), /data (JSON para polling) e /export (download .txt).
- system_logs.html: terminal escuro com colorização por nível ([RAG], [WEB], [ERROR], etc.), auto-refresh a cada 5 s, pausa scroll ao rolar para cima, botões Atualizar / Exportar / Limpar tela.