### PR TITLE
fix: adiciona tratamento de erros no pipeline RAG e corrige busca web

### DIFF
--- a/apps/core/chat/agents/institutional_agent.py
+++ b/apps/core/chat/agents/institutional_agent.py
@@ -688,7 +688,11 @@ def consulta_institucional(
     from datetime import datetime
     today = today or datetime.now().strftime("%d/%m/%Y")
 
-    search_query = _generate_search_query(question, conversation_context, user_profile)
+    try:
+        search_query = _generate_search_query(question, conversation_context, user_profile)
+    except Exception as e:
+        print(f"[RAG][ERROR] Falha ao gerar query de busca: {e}")
+        search_query = question
     retrieval = retrieve_with_threshold(search_query, k=k, score_threshold=score_threshold)
 
     if retrieval.get("status") != "success":
@@ -707,16 +711,26 @@ def consulta_institucional(
 
     llm = _get_llm()
     chain = ChatPromptTemplate.from_template(get_rag_answer_prompt()) | llm | StrOutputParser()
-    answer = chain.invoke(
-        {
-            "context": context,
-            "question": (question or "").strip(),
-            "not_found_answer": NOT_FOUND_ANSWER,
-            "conversation_context": (conversation_context or "").strip() or "Sem histórico relevante.",
-            "user_profile": (user_profile or "").strip() or "Nenhuma informação adicional conhecida.",
-            "today": today,
+    try:
+        answer = chain.invoke(
+            {
+                "context": context,
+                "question": (question or "").strip(),
+                "not_found_answer": NOT_FOUND_ANSWER,
+                "conversation_context": (conversation_context or "").strip() or "Sem histórico relevante.",
+                "user_profile": (user_profile or "").strip() or "Nenhuma informação adicional conhecida.",
+                "today": today,
+            }
+        )
+    except Exception as e:
+        print(f"[RAG][ERROR] Falha na chamada ao LLM: {e}")
+        return {
+            "status": "error",
+            "answer": NOT_FOUND_ANSWER,
+            "sources": [],
+            "docs": docs,
+            "rendered": f"Resposta:\n{NOT_FOUND_ANSWER}",
         }
-    )
 
     answer = (answer or "").strip()
     if _is_not_found_answer(answer):
@@ -762,16 +776,20 @@ def consulta_institucional(
                 docs2 = retrieval2.get("docs") or []
                 sources2 = retrieval2.get("sources") or []
                 context2 = _format_context(docs2)
-                answer2 = chain.invoke(
-                    {
-                        "context": context2,
-                        "question": (question or "").strip(),
-                        "not_found_answer": NOT_FOUND_ANSWER,
-                        "conversation_context": (conversation_context or "").strip() or "Sem histórico relevante.",
-                        "user_profile": (user_profile or "").strip() or "Nenhuma informação adicional conhecida.",
-                        "today": today,
-                    }
-                )
+                try:
+                    answer2 = chain.invoke(
+                        {
+                            "context": context2,
+                            "question": (question or "").strip(),
+                            "not_found_answer": NOT_FOUND_ANSWER,
+                            "conversation_context": (conversation_context or "").strip() or "Sem histórico relevante.",
+                            "user_profile": (user_profile or "").strip() or "Nenhuma informação adicional conhecida.",
+                            "today": today,
+                        }
+                    )
+                except Exception as e:
+                    print(f"[RAG][RETRY {i}][ERROR] Falha na chamada ao LLM: {e}")
+                    continue
                 answer2 = (answer2 or "").strip()
                 if answer2 and not _is_not_found_answer(answer2):
                     print(f"[RAG][RETRY {i}] Retry bem-sucedido.")

--- a/apps/core/chat/agents/web_agent.py
+++ b/apps/core/chat/agents/web_agent.py
@@ -12,7 +12,7 @@ def _get_tavily_tool():
     tavily_api_key = os.getenv("TAVILY_API_KEY")
 
     if tavily_api_key:
-        return TavilySearch(max_results=2, tavily_api_key=tavily_api_key)
+        return TavilySearch(max_results=4, tavily_api_key=tavily_api_key)
 
     @tool
     def disabled_search(query: str) -> str:
@@ -46,7 +46,13 @@ _SENTIMENT_WORDS = {
 }
 
 # Termos que indicam conteúdo relacionado ao IFPI
-_IFPI_TERMS = {"ifpi", "instituto federal", "piauí", "piauí", "federal do piauí"}
+_IFPI_TERMS = {
+    "ifpi", "instituto federal", "piauí", "piauí", "federal do piauí",
+    "campus teresina", "campus parnaíba", "campus floriano", "campus picos",
+    "campus oeiras", "campus corrente", "campus uruçuí", "campus valença",
+    "campus angical", "campus campo maior", "campus cocal", "campus paulistana",
+    "campus piripiri", "campus pedro ii", "campus São raimundo nonato",
+}
 
 
 def _results_are_ifpi_related(results: list[dict[str, Any]]) -> bool:


### PR DESCRIPTION
- Envolve chamadas ao LLM no agente institucional com try/except para evitar travamento quando a API Gemini/Vertex AI falha ou expira
- Fallback para a query original se _generate_search_query lançar exceção
- Retries do RAG continuam para o próximo quando o LLM falha (continue)
- Corrige max_results=2→4 no TavilySearch (estava limitando resultados desde a inicialização, ignorando a sobrescrita em runtime)
- Expande _IFPI_TERMS com nomes de campus para que o filtro de escopo não rejeite resultados válidos que mencionam campus específicos