### PR TITLE
fix: corrige bot travado substituindo gemini-2.5-flash e adicionando …

### DIFF
--- a/apps/core/chat/graph/runner.py
+++ b/apps/core/chat/graph/runner.py
@@ -1,6 +1,7 @@
 import difflib
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from typing import Any
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -74,7 +75,21 @@ def run_chatbot(
     structured = None
 
     print(f"--- Iniciando execução do grafo para: {user_input[:50]}... ---")
-    final_state = get_graph().invoke(state)
+    _GRAPH_TIMEOUT = 60  # segundos — evita que o bot fique "digitando" para sempre
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(get_graph().invoke, state)
+            final_state = future.result(timeout=_GRAPH_TIMEOUT)
+    except FuturesTimeoutError:
+        execution_time = time.time() - start_time
+        print(f"[RUNNER][TIMEOUT] Grafo não respondeu em {_GRAPH_TIMEOUT}s — retornando fallback.")
+        return {
+            "response": "Resposta:\nDesculpe, a resposta demorou mais do que o esperado. Tente novamente em instantes.",
+            "status": "error",
+            "answer": None,
+            "sources": [],
+            "thoughts": None,
+        }
     execution_time = time.time() - start_time
     print(f"--- Execução concluída em {execution_time:.2f} segundos ---")
 

--- a/apps/core/llm_config.py
+++ b/apps/core/llm_config.py
@@ -14,7 +14,12 @@ def get_llm():
     gemini_api_key = os.getenv("GEMINI_API_KEY")
     if gemini_api_key:
         from langchain_google_genai import ChatGoogleGenerativeAI
-        return ChatGoogleGenerativeAI(model="gemini-2.5-flash", google_api_key=gemini_api_key, temperature=0.0)
+        return ChatGoogleGenerativeAI(
+            model="gemini-2.0-flash",   # 2.5-flash é thinking model — muito lento para chatbot
+            google_api_key=gemini_api_key,
+            temperature=0.0,
+            request_timeout=25,         # Timeout de 25s para não travar o bot
+        )
 
     # Fallback para Vertex AI
     from vertexai import init as vertex_init
@@ -27,4 +32,8 @@ def get_llm():
 
     vertex_init(project=project, location=location)
 
-    return ChatVertexAI(model="gemini-2.5-flash", temperature=0.0)
+    return ChatVertexAI(
+        model="gemini-2.0-flash",   # 2.5-flash é thinking model — muito lento para chatbot
+        temperature=0.0,
+        request_timeout=25,         # Timeout de 25s para não travar o bot
+    )


### PR DESCRIPTION
…timeouts

gemini-2.5-flash é um thinking model que pode levar 30-60s para responder, causando o sintoma de 'digitando para sempre'. Trocado por gemini-2.0-flash (não-thinking) que é muito mais rápido para uso em chatbot.

Também adicionado request_timeout=25s no LLM e timeout global de 60s no runner via ThreadPoolExecutor, garantindo que o bot nunca trave indefinidamente mesmo em caso de lentidão da API.