### PR TITLE
fix: corrige timeout duplo e reduz timeout LLM para caber no pipeline

### DIFF
--- a/apps/core/chat/graph/runner.py
+++ b/apps/core/chat/graph/runner.py
@@ -76,11 +76,13 @@ def run_chatbot(
 
     print(f"--- Iniciando execução do grafo para: {user_input[:50]}... ---")
     _GRAPH_TIMEOUT = 60  # segundos — evita que o bot fique "digitando" para sempre
+    executor = ThreadPoolExecutor(max_workers=1)
     try:
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(get_graph().invoke, state)
-            final_state = future.result(timeout=_GRAPH_TIMEOUT)
+        future = executor.submit(get_graph().invoke, state)
+        final_state = future.result(timeout=_GRAPH_TIMEOUT)
     except FuturesTimeoutError:
+        # shutdown(wait=False) evita bloquear aqui enquanto o thread ainda roda
+        executor.shutdown(wait=False)
         execution_time = time.time() - start_time
         print(f"[RUNNER][TIMEOUT] Grafo não respondeu em {_GRAPH_TIMEOUT}s — retornando fallback.")
         return {
@@ -90,6 +92,7 @@ def run_chatbot(
             "sources": [],
             "thoughts": None,
         }
+    executor.shutdown(wait=False)
     execution_time = time.time() - start_time
     print(f"--- Execução concluída em {execution_time:.2f} segundos ---")
 

--- a/apps/core/llm_config.py
+++ b/apps/core/llm_config.py
@@ -18,7 +18,7 @@ def get_llm():
             model="gemini-2.0-flash",   # 2.5-flash é thinking model — muito lento para chatbot
             google_api_key=gemini_api_key,
             temperature=0.0,
-            request_timeout=25,         # Timeout de 25s para não travar o bot
+            request_timeout=15,         # 15s por chamada — pipeline RAG+web+conv cabe em 60s
         )
 
     # Fallback para Vertex AI
@@ -35,5 +35,5 @@ def get_llm():
     return ChatVertexAI(
         model="gemini-2.0-flash",   # 2.5-flash é thinking model — muito lento para chatbot
         temperature=0.0,
-        request_timeout=25,         # Timeout de 25s para não travar o bot
+        request_timeout=15,         # 15s por chamada — pipeline RAG+web+conv cabe em 60s
     )


### PR DESCRIPTION
- runner.py: substitui `with ThreadPoolExecutor` por shutdown(wait=False) para o fallback retornar imediatamente ao esgotar 60s, sem bloquear esperando o thread terminar (era o que causava ~2min de espera)
- llm_config.py: reduz request_timeout de 25s para 15s por chamada LLM; com pipeline RAG+web+conv (até 3 chamadas sequenciais), 15s×3=45s cabe com folga dentro do limite de 60s do grafo